### PR TITLE
updated rosinstall package list

### DIFF
--- a/mir_navigation/mir_2dnav/ros/launch/nav_common.launch
+++ b/mir_navigation/mir_2dnav/ros/launch/nav_common.launch
@@ -9,7 +9,7 @@
   </include>
     
   <!-- visualize navigation goals -->
-  <node pkg="mcr_navigation_tools" type="navigation_goals_as_marker" name="navigation_goals_as_marker" ns="mcr_navigation"/>
+  <include file="$(find mcr_navigation_tools)/ros/launch/pose_visualiser.launch" />
 
   <!-- map server -->
   <arg name="map" default="$(find mcr_default_env_config)/$(arg robot_env)/map.yaml" />

--- a/repository.rosinstall
+++ b/repository.rosinstall
@@ -39,6 +39,16 @@
     version: master
 
 - git:
+    local-name: mas_navigation
+    uri: git@github.com:b-it-bots/mas_navigation.git
+    version: kinetic
+
+- git:
+    local-name: mas_perception
+    uri: git@github.com:b-it-bots/mas_perception.git
+    version: kinetic
+
+- git:
     local-name: unmerged_packages_for_testing
     uri: git@github.com:b-it-bots/unmerged_packages_for_testing.git
     version: kinetic


### PR DESCRIPTION
Due to the seperation of `mas_perception` and `mas_navigation` repos, there were build errors for few packages. For example, `mcr_perception_msgs` was not found for few packages from `unmerged_packages_for_testing`.

**Changes**
- Added git repo information for `mas_perception` and `mas_navigation` in `repository.rosinstall`