### PR TITLE
[barrier_tape...] CMake find OpenCV 3.2

### DIFF
--- a/mir_perception/mir_barrier_tape_detection/CMakeLists.txt
+++ b/mir_perception/mir_barrier_tape_detection/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(catkin REQUIRED
     tf
 )
 
-find_package(OpenCV 3.3 REQUIRED)
+find_package(OpenCV 3.2 REQUIRED)
 find_package(PCL 1.7 REQUIRED)
 
 generate_dynamic_reconfigure_options(


### PR DESCRIPTION
This was finding 3.3, which isn't the default version.
There was no strong reason to use 3.3, switch to 3.2

OpenCV 3.2 should be available on Kinetic and newer.
Tested on Melodic.

http://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021

http://wiki.ros.org/opencv3