### PR TITLE
Fixed bugs in barrier tape detection

### DIFF
--- a/mir_navigation/mir_2dnav/ros/config/dwa/costmap_common_params.yaml
+++ b/mir_navigation/mir_2dnav/ros/config/dwa/costmap_common_params.yaml
@@ -3,7 +3,7 @@ map_type: costmap           # default: "voxel"
 obstacle_range: 2.5         # default: 2.5 
 raytrace_range: 3.0         # default: 3.0
 #
-observation_sources: laser_scanner_front laser_scanner_rear laser_scanner_barrier
+observation_sources: laser_scanner_front laser_scanner_rear laser_scanner_barrier_front laser_scanner_barrier_rear
 #
 laser_scanner_front: {sensor_frame: base_laser_front_link, data_type: LaserScan, topic: /scan_front, expected_update_rate: 1.2, observation_persistence: 0.0,  marking: true, clearing: true, min_obstacle_height: -0.10, max_obstacle_height: 2.0}
 ## default sensor_frame : ""
@@ -26,4 +26,5 @@ laser_scanner_rear: {sensor_frame: base_laser_rear_link, data_type: LaserScan, t
 ## default clearing : false
 ## default min_obstacle_height : 0.0
 ## default max_obstacle_height: 2.0
-laser_scanner_barrier: {sensor_frame: base_laser_front_link, data_type: LaserScan, topic: /barrier_tape/scan, observation_persistence: 600.0,  marking: true, clearing: true, min_obstacle_height: -0.5, max_obstacle_height: 2.0}
+laser_scanner_barrier_front: {sensor_frame: base_laser_front_link, data_type: LaserScan, topic: /barrier_tape/scan_front, observation_persistence: 600.0,  marking: true, clearing: true, min_obstacle_height: -0.5, max_obstacle_height: 2.0}
+laser_scanner_barrier_rear: {sensor_frame: base_laser_rear_link, data_type: LaserScan, topic: /barrier_tape/scan_rear, observation_persistence: 600.0,  marking: true, clearing: true, min_obstacle_height: -0.5, max_obstacle_height: 2.0}

--- a/mir_perception/mir_barrier_tape_detection/ros/launch/barrier_tape_detection.launch
+++ b/mir_perception/mir_barrier_tape_detection/ros/launch/barrier_tape_detection.launch
@@ -1,26 +1,21 @@
 <?xml version="1.0"?>
 <launch>
-  <!-- Barrier tape detection node-->
-    <node pkg="mir_barrier_tape_detection" type="barrier_tape_detection_node" name="barrier_tape_detection" ns="mir_perception/front_camera" output="screen" respawn="true">
-    <remap from="~input_rgb_image" to="/arm_cam3d/rgb/image_raw"/>
-    <remap from="~input_pointcloud" to="/arm_cam3d/depth_registered/points"/>
-    <remap from="~camera_info" to="/arm_cam3d/rgb/camera_info"/>
-    <param name="loop_rate" type="int" value="30" />
-    <param name="target_frame" value="map"/>
-  </node>
-
-  <node pkg="mir_barrier_tape_detection" type="barrier_tape_detection_node" name="barrier_tape_detection" ns="mir_perception/back_camera" output="screen" respawn="true">
-    <remap from="~input_rgb_image" to="/camera/color/image_raw"/>
-    <remap from="~input_pointcloud" to="/camera/depth/color/points"/>
-    <remap from="~camera_info" to="/camera/color/camera_info"/>
-    <param name="loop_rate" type="int" value="30" />
-    <param name="target_frame" value="map"/>
-  </node>
-  <!-- Point cloud to laser scan conversion-->
-  <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan">
-        <remap from="cloud_in" to="/mir_perception/barrier_tape_detection/output/yellow_barrier_tape_pointcloud"/>
-        <remap from="scan" to="barrier_tape/scan" />
-       <rosparam>
+  <!-- Barrier tape detection node -->
+  <group ns="mir_perception/front_camera">
+      <node pkg="mir_barrier_tape_detection" type="barrier_tape_detection_node" name="barrier_tape_detection" output="screen" respawn="true"> 
+          <remap from="~input_rgb_image" to="/arm_cam3d/rgb/image_raw"/> 
+          <remap from="~input_pointcloud" to="/arm_cam3d/depth_registered/points"/> 
+          <remap from="~camera_info" to="/arm_cam3d/rgb/camera_info"/> 
+          <param name="loop_rate" type="int" value="30" /> 
+          <param name="target_frame" value="map"/> 
+          <remap from="~event_in" to="/mir_perception/barrier_tape_detection/event_in"/> 
+          <remap from="~output/yellow_barrier_tape_pointcloud" to="/mir_perception/barrier_tape_detection/output/yellow_barrier_tape_pointcloud"/> 
+      </node> 
+      <!-- Point cloud to laser scan conversion-->
+      <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan">
+          <remap from="cloud_in" to="/mir_perception/barrier_tape_detection/output/yellow_barrier_tape_pointcloud"/>
+          <remap from="scan" to="/barrier_tape/scan_front" />
+          <rosparam>
             target_frame: base_laser_front_link # Leave disabled to output scan in pointcloud frame
             transform_tolerance: 0.01
             min_height: -1.0
@@ -39,6 +34,49 @@
             # 1 : Single threaded
             # 2->inf : Parallelism level
             concurrency_level: 1
-        </rosparam>
-  </node>
+          </rosparam>
+      </node>
+  </group>
+
+  <group ns="mir_perception/back_camera">
+      <node pkg="mir_barrier_tape_detection" type="barrier_tape_detection_node" name="barrier_tape_detection"  output="screen" respawn="true">
+          <remap from="~input_rgb_image" to="/camera/color/image_rect_color"/>
+          <remap from="~input_pointcloud" to="/camera/depth_registered/points"/>
+          <remap from="~camera_info" to="/camera/color/camera_info"/>
+          <param name="loop_rate" type="int" value="1" />
+          <param name="target_frame" value="map"/>
+          <remap from="~event_in" to="/mir_perception/barrier_tape_detection/event_in"/>
+          <remap from="~output/yellow_barrier_tape_pointcloud" to="/mir_perception/barrier_tape_detection/output/yellow_barrier_tape_pointcloud"/>
+          <rosparam> 
+        color_thresh_min_h: 30
+        color_thresh_min_v: 28
+          </rosparam> 
+      </node>
+
+      <!-- Point cloud to laser scan conversion-->
+      <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan">
+          <remap from="cloud_in" to="/mir_perception/barrier_tape_detection/output/yellow_barrier_tape_pointcloud"/>
+          <remap from="scan" to="/barrier_tape/scan_rear" />
+          <rosparam>
+            target_frame: base_laser_rear_link # Leave disabled to output scan in pointcloud frame
+            transform_tolerance: 0.01
+            min_height: -1.0
+            max_height: 5.0
+
+            angle_min: -1.5708 # -M_PI/2
+            angle_max: 1.5708 # M_PI/2
+            angle_increment: 0.0087 # M_PI/360.0
+            scan_time: 0.03333
+            range_min: 0.001
+            range_max: 5.0
+            use_inf: true
+
+            # Concurrency level, affects number of pointclouds queued for processing, thread number governed by nodelet manager
+            # 0 : Detect number of cores
+            # 1 : Single threaded
+            # 2->inf : Parallelism level
+            concurrency_level: 1
+          </rosparam>
+      </node>
+  </group>
 </launch>

--- a/mir_perception/mir_barrier_tape_detection/ros/src/barrier_tape_detection_ros.cpp
+++ b/mir_perception/mir_barrier_tape_detection/ros/src/barrier_tape_detection_ros.cpp
@@ -248,6 +248,7 @@ void BarrierTapeDetectionRos::convertPointCloudToXYZImage(cv::Mat &output_xyz_im
         index++;
     }
     xyz_frame.copyTo(output_xyz_image);
+    delete xyz_frame_buffer;
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Fixed bugs in the barrier tape detection 

## Changelog
- Fix excessive memory usage bug in barrier tape detection
- Fix front and rear barrier tape detection. Now works simultaneously

## Related PRs
 Closes https://github.com/b-it-bots/unmerged_packages_for_testing/issues/96

## Checklist:
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [ ] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [ ] I have updated the documentation accordingly.

cc: @abhishek098 @sthoduka 