### PR TITLE
Added bringup and moveit for youbot arm (without base)

### DIFF
--- a/mir_manipulation/mir_moveit_youbot/youbot-brsu-arm/move_group.launch
+++ b/mir_manipulation/mir_moveit_youbot/youbot-brsu-arm/move_group.launch
@@ -1,0 +1,8 @@
+<launch>
+
+  <arg name="planner_pipeline" default="ompl" />
+  <include file="$(find mir_moveit_youbot_brsu_arm)/launch/move_group.launch">
+     <arg name="planner_pipeline" value="$(arg planner_pipeline)" />
+  </include>
+  
+</launch>

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/.setup_assistant
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/.setup_assistant
@@ -1,0 +1,8 @@
+moveit_setup_assistant_config:
+  URDF:
+    package: mir_hardware_config
+    relative_path: youbot-brsu-1/urdf/robot.urdf.xacro
+  SRDF:
+    relative_path: config/youbot.srdf
+  CONFIG:
+    generated_timestamp: 1428681804

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/CMakeLists.txt
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(mir_moveit_youbot_brsu_arm)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/config/controllers.yaml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/config/controllers.yaml
@@ -1,0 +1,18 @@
+controller_list:
+  - name: arm_1/arm_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
+      - arm_joint_1
+      - arm_joint_2
+      - arm_joint_3
+      - arm_joint_4
+      - arm_joint_5
+  - name: arm_1/gripper_controller
+    action_ns: /
+    type: GripperCommand
+    default: true
+    joints: 
+      - gripper_finger_joint_l
+      - gripper_finger_joint_r

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/config/fake_controllers.yaml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/config/fake_controllers.yaml
@@ -1,0 +1,12 @@
+controller_list:
+  - name: fake_arm_1_controller
+    joints:
+      - arm_joint_1
+      - arm_joint_2
+      - arm_joint_3
+      - arm_joint_4
+      - arm_joint_5
+  - name: fake_arm_1_gripper_controller
+    joints:
+      - gripper_finger_joint_l
+      - gripper_finger_joint_r

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/config/interpolation_planning.yaml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/config/interpolation_planning.yaml
@@ -1,0 +1,11 @@
+planner_configs:
+  Interpolation:
+    type_1: Trapezoidal
+arm_1:
+  planner_configs:
+    - Interpolation
+  planner_minimum_sample_time: 0.1
+arm_1_gripper:
+  planner_configs:
+    - Interpolation
+  planner_minimum_sample_time: 0.1

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/config/joint_limits.yaml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/config/joint_limits.yaml
@@ -1,0 +1,36 @@
+joint_limits:
+  arm_joint_3:
+    has_velocity_limits: true
+    max_velocity: 1.57079632679
+    has_acceleration_limits: true
+    max_acceleration: 1.571
+  arm_joint_2:
+    has_velocity_limits: true
+    max_velocity: 1.57079632679
+    has_acceleration_limits: true
+    max_acceleration: 1.571
+  arm_joint_4:
+    has_velocity_limits: true
+    max_velocity: 1.57079632679
+    has_acceleration_limits: true
+    max_acceleration: 1.571
+  gripper_finger_joint_r:
+    has_velocity_limits: true
+    max_velocity: 0.1
+    has_acceleration_limits: true
+    max_acceleration: 0.05
+  arm_joint_5:
+    has_velocity_limits: true
+    max_velocity: 1.57079632679
+    has_acceleration_limits: true
+    max_acceleration: 1.571
+  arm_joint_1:
+    has_velocity_limits: true
+    max_velocity: 1.57079632679
+    has_acceleration_limits: true
+    max_acceleration: 1.571
+  gripper_finger_joint_l:
+    has_velocity_limits: true
+    max_velocity: 0.1
+    has_acceleration_limits: true
+    max_acceleration: 0.05

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/config/kinematics.yaml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/config/kinematics.yaml
@@ -1,0 +1,5 @@
+arm_1:
+  kinematics_solver: youbot_arm_kinematics_moveit::KinematicsPlugin
+  kinematics_solver_search_resolution: 0.01
+  kinematics_solver_timeout: 0.1
+  kinematics_solver_attempts: 1

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/config/ompl_planning.yaml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/config/ompl_planning.yaml
@@ -1,0 +1,53 @@
+planner_configs:
+  SBLkConfigDefault:
+    type: geometric::SBL
+  ESTkConfigDefault:
+    type: geometric::EST
+  LBKPIECEkConfigDefault:
+    type: geometric::LBKPIECE
+  BKPIECEkConfigDefault:
+    type: geometric::BKPIECE
+  KPIECEkConfigDefault:
+    type: geometric::KPIECE
+  RRTkConfigDefault:
+    type: geometric::RRT
+  RRTConnectkConfigDefault:
+    type: geometric::RRTConnect
+  RRTstarkConfigDefault:
+    type: geometric::RRTstar
+  TRRTkConfigDefault:
+    type: geometric::TRRT
+  PRMkConfigDefault:
+    type: geometric::PRM
+  PRMstarkConfigDefault:
+    type: geometric::PRMstar
+arm_1:
+  planner_configs:
+    - SBLkConfigDefault
+    - ESTkConfigDefault
+    - LBKPIECEkConfigDefault
+    - BKPIECEkConfigDefault
+    - KPIECEkConfigDefault
+    - RRTkConfigDefault
+    - RRTConnectkConfigDefault
+    - RRTstarkConfigDefault
+    - TRRTkConfigDefault
+    - PRMkConfigDefault
+    - PRMstarkConfigDefault
+  projection_evaluator: joints(arm_joint_1,arm_joint_2)
+  longest_valid_segment_fraction: 0.05
+arm_1_gripper:
+  planner_configs:
+    - SBLkConfigDefault
+    - ESTkConfigDefault
+    - LBKPIECEkConfigDefault
+    - BKPIECEkConfigDefault
+    - KPIECEkConfigDefault
+    - RRTkConfigDefault
+    - RRTConnectkConfigDefault
+    - RRTstarkConfigDefault
+    - TRRTkConfigDefault
+    - PRMkConfigDefault
+    - PRMstarkConfigDefault
+  projection_evaluator: joints(gripper_finger_joint_l,gripper_finger_joint_r)
+  longest_valid_segment_fraction: 0.05

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/config/youbot.srdf
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/config/youbot.srdf
@@ -1,0 +1,275 @@
+<?xml version="1.0" ?>
+<!--This does not replace URDF, and is not an extension of URDF.
+    This is a format for representing semantic information about the robot structure.
+    A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
+-->
+<robot name="youbot">
+    <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
+    <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
+    <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
+    <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
+    <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
+    <group name="arm_1">
+        <joint name="arm_joint_1" />
+        <joint name="arm_joint_2" />
+        <joint name="arm_joint_3" />
+        <joint name="arm_joint_4" />
+        <joint name="arm_joint_5" />
+    </group>
+    <group name="arm_1_gripper">
+        <joint name="gripper_finger_joint_l" />
+        <joint name="gripper_finger_joint_r" />
+    </group>
+    <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
+    <group_state name="camera_calibration_snake" group="arm_1">
+        <joint name="arm_joint_1" value="2.14317" />
+        <joint name="arm_joint_2" value="1.13125" />
+        <joint name="arm_joint_3" value="-2.54711" />
+        <joint name="arm_joint_4" value="3.35851" />
+        <joint name="arm_joint_5" value="2.92728" />
+    </group_state>
+    <group_state name="camera_calibration_elbow" group="arm_1">
+        <joint name="arm_joint_1" value="5.30383" />
+        <joint name="arm_joint_2" value="0.069407" />
+        <joint name="arm_joint_3" value="-0.889008" />
+        <joint name="arm_joint_4" value="3.426" />
+        <joint name="arm_joint_5" value="2.9831" />
+    </group_state>
+    <group_state name="look_at_workspace" group="arm_1">
+        <joint name="arm_joint_1" value="2.1532" />
+        <joint name="arm_joint_2" value="0.5835" />
+        <joint name="arm_joint_3" value="-1.007" />
+        <joint name="arm_joint_4" value="3.3501" />
+        <joint name="arm_joint_5" value="2.9142" />
+    </group_state>
+    <group_state name="look_at_workspace_left" group="arm_1">
+        <joint name="arm_joint_1" value="1.6851" />
+        <joint name="arm_joint_2" value="1.044" />
+        <joint name="arm_joint_3" value="-1.6268" />
+        <joint name="arm_joint_4" value="3.48012" />
+        <joint name="arm_joint_5" value="2.9135" />
+    </group_state>
+    <group_state name="look_at_workspace_right" group="arm_1">
+        <joint name="arm_joint_1" value="2.588" />
+        <joint name="arm_joint_2" value="1.0874" />
+        <joint name="arm_joint_3" value="-1.632" />
+        <joint name="arm_joint_4" value="3.48012" />
+        <joint name="arm_joint_5" value="2.9135" />
+    </group_state>
+    <group_state name="folded" group="arm_1">
+        <joint name="arm_joint_1" value="0.02" />
+        <joint name="arm_joint_2" value="0.02" />
+        <joint name="arm_joint_3" value="-0.02" />
+        <joint name="arm_joint_4" value="0.02" />
+        <joint name="arm_joint_5" value="0.02" />
+    </group_state>
+    <group_state name="within_footprint_forward" group="arm_1">
+        <joint name="arm_joint_1" value="2.09854" />
+        <joint name="arm_joint_2" value="0.0769791" />
+        <joint name="arm_joint_3" value="-1.86351" />
+        <joint name="arm_joint_4" value="3.05427" />
+        <joint name="arm_joint_5" value="2.94987" />
+    </group_state>
+    <group_state name="candle" group="arm_1">
+        <joint name="arm_joint_1" value="2.1642" />
+        <joint name="arm_joint_2" value="1.13446" />
+        <joint name="arm_joint_3" value="-2.54818" />
+        <joint name="arm_joint_4" value="1.78896" />
+        <joint name="arm_joint_5" value="2.93075" />
+    </group_state>
+    <group_state name="platform_middle" group="arm_1">
+        <joint name="arm_joint_1" value="2.1404" />
+        <joint name="arm_joint_2" value="0.6366" />
+        <joint name="arm_joint_3" value="-3.628" />
+        <joint name="arm_joint_4" value="0.3174" />
+        <joint name="arm_joint_5" value="2.9493" />
+    </group_state>
+    <group_state name="platform_middle_pre" group="arm_1">
+        <joint name="arm_joint_1" value="2.13374" />
+        <joint name="arm_joint_2" value="0.96731" />
+        <joint name="arm_joint_3" value="-3.70453" />
+        <joint name="arm_joint_4" value="0.33765" />
+        <joint name="arm_joint_5" value="2.95327" />
+    </group_state>
+    <group_state name="platform_intermediate" group="arm_1">
+        <joint name="arm_joint_1" value="2.1642" />
+        <joint name="arm_joint_2" value="1.86356" />
+        <joint name="arm_joint_3" value="-4.1407" />
+        <joint name="arm_joint_4" value="1.08195" />
+        <joint name="arm_joint_5" value="2.8894" />
+    </group_state>
+    <group_state name="platform_left" group="arm_1">
+        <joint name="arm_joint_1" value="2.4710" />
+        <joint name="arm_joint_2" value="0.5519" />
+        <joint name="arm_joint_3" value="-3.4836" />
+        <joint name="arm_joint_4" value="0.2853" />
+        <joint name="arm_joint_5" value="3.2877" />
+    </group_state>
+    <group_state name="platform_left_pre" group="arm_1">
+        <joint name="arm_joint_1" value="2.52048" />
+        <joint name="arm_joint_2" value="0.79142" />
+        <joint name="arm_joint_3" value="-3.458202" />
+        <joint name="arm_joint_4" value="0.24957" />
+        <joint name="arm_joint_5" value="3.22097" />
+    </group_state>
+    <group_state name="platform_right" group="arm_1">
+        <joint name="arm_joint_1" value="1.8139" />
+        <joint name="arm_joint_2" value="0.5608" />
+        <joint name="arm_joint_3" value="-3.4970" />
+        <joint name="arm_joint_4" value="0.2875" />
+        <joint name="arm_joint_5" value="2.5359" />
+    </group_state>
+    <group_state name="platform_right_pre" group="arm_1">
+        <joint name="arm_joint_1" value="1.77694" />
+        <joint name="arm_joint_2" value="0.91176" />
+        <joint name="arm_joint_3" value="-3.56979" />
+        <joint name="arm_joint_4" value="0.28413" />
+        <joint name="arm_joint_5" value="2.536017" />
+    </group_state>
+    <group_state name="pre_grasp_old" group="arm_1">
+        <joint name="arm_joint_1" value="2.2219" />
+        <joint name="arm_joint_2" value="1.4" />
+        <joint name="arm_joint_3" value="-1.42" />
+        <joint name="arm_joint_4" value="3.21" />
+        <joint name="arm_joint_5" value="2.92" />
+    </group_state>
+    <group_state name="pre_grasp" group="arm_1">
+        <joint name="arm_joint_1" value="2.2108" />
+        <joint name="arm_joint_2" value="1.77536" />
+        <joint name="arm_joint_3" value="-1.68529" />
+        <joint name="arm_joint_4" value="3.40588" />
+        <joint name="arm_joint_5" value="2.93889" />
+    </group_state>
+    <group_state name="pre_grasp_visual_servoing" group="arm_1">
+        <joint name="arm_joint_1" value="2.2219" />
+        <joint name="arm_joint_2" value="1.4" />
+        <joint name="arm_joint_3" value="-1.42" />
+        <joint name="arm_joint_4" value="3.21" />
+        <joint name="arm_joint_5" value="2.92" />
+    </group_state>
+        <group_state name="pre_grasp_vs_china" group="arm_1">
+        <joint name="arm_joint_1" value="2.20153146725" />
+        <joint name="arm_joint_2" value="1.53977309934" />
+        <joint name="arm_joint_3" value="-1.2761934757" />
+        <joint name="arm_joint_4" value="3.17869442035" />
+        <joint name="arm_joint_5" value="2.93944665306" />
+    </group_state>
+    <group_state name="pregrasp_laying" group="arm_1">
+        <joint name="arm_joint_1" value="2.1642" />
+        <joint name="arm_joint_2" value="1.53772" />
+        <joint name="arm_joint_3" value="-1.68493" />
+        <joint name="arm_joint_4" value="2.9719" />
+        <joint name="arm_joint_5" value="2.9175" />
+    </group_state>
+    <group_state name="line/line_1" group="arm_1">
+        <joint name="arm_joint_1" value="1.70302" />
+        <joint name="arm_joint_2" value="1.83053" />
+        <joint name="arm_joint_3" value="-1.44912" />
+        <joint name="arm_joint_4" value="3.03511" />
+        <joint name="arm_joint_5" value="2.36002" />
+    </group_state>
+    <group_state name="line/line_2" group="arm_1">
+        <joint name="arm_joint_1" value="2.16157" />
+        <joint name="arm_joint_2" value="1.75715" />
+        <joint name="arm_joint_3" value="-1.31836" />
+        <joint name="arm_joint_4" value="2.94389" />
+        <joint name="arm_joint_5" value="2.87216" />
+    </group_state>
+    <group_state name="line/line_3" group="arm_1">
+        <joint name="arm_joint_1" value="2.58275" />
+        <joint name="arm_joint_2" value="2.17412" />
+        <joint name="arm_joint_3" value="-1.12527" />
+        <joint name="arm_joint_4" value="3.37404" />
+        <joint name="arm_joint_5" value="3.37860" />
+    </group_state>
+    <group_state name="line/line_4" group="arm_1">
+        <joint name="arm_joint_1" value="1.980" />
+        <joint name="arm_joint_2" value="1.933841" />
+        <joint name="arm_joint_3" value="-1.49634" />
+        <joint name="arm_joint_4" value="2.670995" />
+        <joint name="arm_joint_5" value="2.823605" />
+    </group_state>
+    <group_state name="line/line_5" group="arm_1">
+        <joint name="arm_joint_1" value="2.328545" />
+        <joint name="arm_joint_2" value="1.947233" />
+        <joint name="arm_joint_3" value="-1.502450" />
+        <joint name="arm_joint_4" value="2.66473" />
+        <joint name="arm_joint_5" value="2.93420" />
+    </group_state>
+    <group_state name="zigzag/zigzag_1" group="arm_1">
+        <joint name="arm_joint_1" value="1.7453" />
+        <joint name="arm_joint_2" value="2.0889" />
+        <joint name="arm_joint_3" value="-1.963" />
+        <joint name="arm_joint_4" value="2.6887" />
+        <joint name="arm_joint_5" value="2.92261" />
+    </group_state>
+    <group_state name="zigzag/zigzag_2" group="arm_1">
+        <joint name="arm_joint_1" value="2.1991" />
+        <joint name="arm_joint_2" value="2.0529" />
+        <joint name="arm_joint_3" value="-1.871" />
+        <joint name="arm_joint_4" value="2.6464" />
+        <joint name="arm_joint_5" value="2.91953" />
+    </group_state>
+    <group_state name="zigzag/zigzag_3" group="arm_1">
+        <joint name="arm_joint_1" value="2.5482" />
+        <joint name="arm_joint_2" value="2.0688" />
+        <joint name="arm_joint_3" value="-1.8403" />
+        <joint name="arm_joint_4" value="2.5405" />
+        <joint name="arm_joint_5" value="2.92261" />
+    </group_state>
+    <group_state name="ppt_safe_place" group="arm_1">
+        <joint name="arm_joint_1" value="2.19229" />
+        <joint name="arm_joint_2" value="2.18748" />
+        <joint name="arm_joint_3" value="-1.92496" />
+        <joint name="arm_joint_4" value="2.72031" />
+        <joint name="arm_joint_5" value="2.86783" />
+    </group_state>
+    <group_state name="place_horizontal" group="arm_1">
+        <joint name="arm_joint_1" value="2.1642" />
+        <joint name="arm_joint_2" value="1.5847" />
+        <joint name="arm_joint_3" value="-1.2882" />
+        <joint name="arm_joint_4" value="2.4982" />
+        <joint name="arm_joint_5" value="2.91953" />
+    </group_state>
+    <group_state name="place_vertical" group="arm_1">
+        <joint name="arm_joint_1" value="2.1991" />
+        <joint name="arm_joint_2" value="1.5847" />
+        <joint name="arm_joint_3" value="-1.2882" />
+        <joint name="arm_joint_4" value="2.4982" />
+        <joint name="arm_joint_5" value="2.91953" />
+    </group_state>
+
+     <group_state name="look_at_turntable" group="arm_1">
+        <joint name="arm_joint_1" value="2.23971" />
+        <joint name="arm_joint_2" value="0.648537" />
+        <joint name="arm_joint_3" value="-1.62819" />
+        <joint name="arm_joint_4" value="3.52223" />
+        <joint name="arm_joint_5" value="2.9871" />
+    </group_state>
+
+    <group_state name="close" group="arm_1_gripper">
+        <joint name="gripper_finger_joint_l" value="0.0" />
+        <joint name="gripper_finger_joint_r" value="0.0" />
+    </group_state>
+    <group_state name="open" group="arm_1_gripper">
+        <joint name="gripper_finger_joint_l" value="1.7" />
+        <joint name="gripper_finger_joint_r" value="1.7" />
+    </group_state>
+    <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
+    <end_effector name="arm_1_gripper" parent_link="arm_link_5" group="arm_1_gripper" parent_group="arm_1" />
+    <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
+    <!-- <virtual_joint name="odom" type="fixed" parent_frame="odom" child_link="base_footprint" /> -->
+    <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="arm_link_0" link2="arm_link_1" reason="Adjacent" />
+    <disable_collisions link1="arm_link_0" link2="arm_link_2" reason="Never" />
+    <disable_collisions link1="arm_link_0" link2="base_link" reason="Never" />
+    <disable_collisions link1="arm_link_1" link2="arm_link_2" reason="Adjacent" />
+    <disable_collisions link1="arm_link_1" link2="base_link" reason="Never" />
+    <disable_collisions link1="arm_link_2" link2="arm_link_3" reason="Adjacent" />
+    <disable_collisions link1="arm_link_2" link2="base_link" reason="Never" />
+    <disable_collisions link1="arm_link_3" link2="arm_link_4" reason="Adjacent" />
+    <disable_collisions link1="arm_link_3" link2="arm_link_5" reason="Never" />
+    <disable_collisions link1="arm_link_3" link2="base_link" reason="Never" />
+    <disable_collisions link1="arm_link_4" link2="arm_link_5" reason="Adjacent" />
+    <disable_collisions link1="gripper_finger_link_l" link2="gripper_finger_link_r" reason="Never" />
+</robot>

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/interpolation_planning_pipeline.launch.xml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/interpolation_planning_pipeline.launch.xml
@@ -1,0 +1,21 @@
+<launch>
+  <!-- Interpolation Planner Plugin for MoveIt! -->
+  <arg name="planning_plugin" value="interpolation_planner_interface/InterpolationPlannerManager" />
+
+  <!-- The request adapters (plugins) used when planning with Interpolation Planner. 
+       ORDER MATTERS -->
+  <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
+				       default_planner_request_adapters/FixWorkspaceBounds
+				       default_planner_request_adapters/FixStartStateBounds
+				       default_planner_request_adapters/FixStartStateCollision
+				       default_planner_request_adapters/FixStartStatePathConstraints" />
+
+  <arg name="start_state_max_bounds_error" value="0.1" />
+
+  <param name="planning_plugin" value="$(arg planning_plugin)" />
+  <param name="request_adapters" value="$(arg planning_adapters)" />
+  <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
+
+  <rosparam command="load" file="$(find mir_moveit_youbot_brsu_arm)/config/interpolation_planning.yaml"/>
+
+</launch>

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/move_group.launch
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/move_group.launch
@@ -1,0 +1,69 @@
+<launch>
+
+  <include file="$(find mir_moveit_youbot_brsu_arm)/launch/planning_context.launch" />
+
+  <!-- GDB Debug Option -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <!-- Verbose Mode Option -->
+  <arg name="info" default="$(arg debug)" />  
+  <arg unless="$(arg info)" name="command_args" value="" />
+  <arg     if="$(arg info)" name="command_args" value="--debug" />
+
+  <!-- move_group settings -->
+  <arg name="allow_trajectory_execution" default="true"/> 
+  <arg name="fake_execution" default="false"/>
+  <arg name="max_safe_path_cost" default="1"/>
+  <arg name="jiggle_fraction" default="0.05" />
+  <arg name="publish_monitored_planning_scene" default="true"/>
+
+  <arg name="planner_pipeline" default="interpolation" />
+
+  <!-- Planning Functionality -->
+  <include ns="move_group" file="$(find mir_moveit_youbot_brsu_arm)/launch/planning_pipeline.launch.xml">
+    <arg name="pipeline" value="$(arg planner_pipeline)" />
+  </include>
+
+  <!-- Trajectory Execution Functionality -->
+  <include ns="move_group" file="$(find mir_moveit_youbot_brsu_arm)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
+    <arg name="moveit_manage_controllers" value="true" />
+    <arg name="moveit_controller_manager" value="youbot" unless="$(arg fake_execution)"/>
+    <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
+  </include>
+
+  <!-- Sensors Functionality -->
+  <include ns="move_group" file="$(find mir_moveit_youbot_brsu_arm)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
+    <arg name="moveit_sensor_manager" value="youbot" /> 
+  </include>
+
+  <!-- Start the actual move_group node/action server -->
+  <node name="move_group" launch-prefix="$(arg launch_prefix)" pkg="moveit_ros_move_group" type="move_group" respawn="false" output="screen" args="$(arg command_args)">
+    <!-- Set the display variable, in case OpenGL code is used internally -->
+    <env name="DISPLAY" value="$(optenv DISPLAY :0)" />
+
+    <param name="allow_trajectory_execution" value="$(arg allow_trajectory_execution)"/>
+    <param name="max_safe_path_cost" value="$(arg max_safe_path_cost)"/>
+    <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
+
+    <!-- MoveGroup capabilities to load -->
+    <param name="capabilities" value="move_group/MoveGroupCartesianPathService
+				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupKinematicsService
+				      move_group/MoveGroupMoveAction
+				      move_group/MoveGroupPickPlaceAction
+				      move_group/MoveGroupPlanService
+				      move_group/MoveGroupQueryPlannersService
+				      move_group/MoveGroupStateValidationService
+				      move_group/MoveGroupGetPlanningSceneService
+				      " />
+
+    <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
+    <param name="planning_scene_monitor/publish_planning_scene" value="$(arg publish_monitored_planning_scene)" />
+    <param name="planning_scene_monitor/publish_geometry_updates" value="$(arg publish_monitored_planning_scene)" />
+    <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
+    <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
+  </node>
+  
+</launch>

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/ompl_planning_pipeline.launch.xml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/ompl_planning_pipeline.launch.xml
@@ -1,0 +1,22 @@
+<launch>
+
+  <!-- OMPL Plugin for MoveIt! -->
+  <arg name="planning_plugin" value="ompl_interface/OMPLPlanner" />
+
+  <!-- The request adapters (plugins) used when planning with OMPL. 
+       ORDER MATTERS -->
+  <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
+				       default_planner_request_adapters/FixWorkspaceBounds
+				       default_planner_request_adapters/FixStartStateBounds
+				       default_planner_request_adapters/FixStartStateCollision
+				       default_planner_request_adapters/FixStartStatePathConstraints" />
+
+  <arg name="start_state_max_bounds_error" value="0.1" />
+
+  <param name="planning_plugin" value="$(arg planning_plugin)" />
+  <param name="request_adapters" value="$(arg planning_adapters)" />
+  <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
+
+  <rosparam command="load" file="$(find mir_moveit_youbot_brsu_arm)/config/ompl_planning.yaml"/>
+
+</launch>

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/planning_context.launch
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/planning_context.launch
@@ -1,0 +1,24 @@
+<launch>
+  <!-- By default we do not overwrite the URDF. Change the following to true to change the default behavior -->
+  <arg name="load_robot_description" default="false"/>
+
+  <!-- The name of the parameter under which the URDF is loaded -->
+  <arg name="robot_description" default="robot_description"/>
+
+  <!-- Load universal robot description format (URDF) -->
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find mir_hardware_config)/youbot-brsu-1/urdf/robot.urdf.xacro'"/>
+
+  <!-- The semantic description that corresponds to the URDF -->
+  <param name="$(arg robot_description)_semantic" textfile="$(find mir_moveit_youbot_brsu_arm)/config/youbot.srdf" />
+  
+  <!-- Load updated joint limits (override information from URDF) -->
+  <group ns="$(arg robot_description)_planning">
+    <rosparam command="load" file="$(find mir_moveit_youbot_brsu_arm)/config/joint_limits.yaml"/>
+  </group>
+
+  <!-- Load default settings for kinematics; these settings are overridden by settings in a node's namespace -->
+  <group ns="$(arg robot_description)_kinematics">
+    <rosparam command="load" file="$(find mir_moveit_youbot_brsu_arm)/config/kinematics.yaml"/>
+  </group>
+  
+</launch>

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/planning_pipeline.launch.xml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/planning_pipeline.launch.xml
@@ -1,0 +1,10 @@
+<launch>
+
+  <!-- This file makes it easy to include different planning pipelines; 
+       It is assumed that all planning pipelines are named XXX_planning_pipeline.launch  -->  
+
+  <arg name="pipeline" default="ompl" />
+
+  <include file="$(find mir_moveit_youbot_brsu_arm)/launch/$(arg pipeline)_planning_pipeline.launch.xml" />
+
+</launch>

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/sensor_manager.launch.xml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/sensor_manager.launch.xml
@@ -1,0 +1,14 @@
+<launch>
+
+  <!-- This file makes it easy to include the settings for sensor managers -->  
+
+  <!-- Params for the octomap monitor -->
+  <!--  <param name="octomap_frame" type="string" value="some frame in which the robot moves" /> -->
+  <param name="octomap_resolution" type="double" value="0.025" />
+  <param name="max_range" type="double" value="5.0" />
+
+  <!-- Load the robot specific sensor manager; this sets the moveit_sensor_manager ROS parameter -->
+  <arg name="moveit_sensor_manager" default="youbot" />
+  <include file="$(find mir_moveit_youbot_brsu_arm)/launch/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
+  
+</launch>

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/trajectory_execution.launch.xml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/trajectory_execution.launch.xml
@@ -1,0 +1,18 @@
+<launch>
+
+  <!-- This file makes it easy to include the settings for trajectory execution  -->  
+
+  <!-- Flag indicating whether MoveIt! is allowed to load/unload  or switch controllers -->
+  <arg name="moveit_manage_controllers" default="true"/>
+  <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
+
+  <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
+  <param name="allowed_execution_duration_scaling" value="2.0"/> <!-- default 1.2 -->
+  <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
+  <param name="allowed_goal_duration_margin" value="3.0"/> <!-- default 0.5 -->
+  
+  <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
+  <arg name="moveit_controller_manager" default="youbot" />
+  <include file="$(find mir_moveit_youbot_brsu_arm)/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml" />
+  
+</launch>

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/youbot_moveit_controller_manager.launch.xml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/youbot_moveit_controller_manager.launch.xml
@@ -1,0 +1,9 @@
+<launch>
+
+  <!-- Set the param that trajectory_execution_manager needs to find the controller plugin -->
+  <param name="moveit_controller_manager" value="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
+
+  <!-- The rest of the params are specific to this plugin -->
+  <rosparam file="$(find mir_moveit_youbot_brsu_arm)/config/controllers.yaml"/>
+
+</launch>

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/youbot_moveit_sensor_manager.launch.xml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/launch/youbot_moveit_sensor_manager.launch.xml
@@ -1,0 +1,3 @@
+<launch>
+
+</launch>

--- a/mir_manipulation/mir_moveit_youbot_brsu_arm/package.xml
+++ b/mir_manipulation/mir_moveit_youbot_brsu_arm/package.xml
@@ -1,0 +1,29 @@
+<package>
+
+  <name>mir_moveit_youbot_brsu_arm</name>
+  <version>0.2.0</version>
+  <description>
+     A package with all the configuration and launch files for using the youbot arm with the MoveIt Motion Planning Framework
+  </description>
+  <author email="assistant@moveit.ros.org">MoveIt Setup Assistant</author>
+  <maintainer email="assistant@moveit.ros.org">MoveIt Setup Assistant</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">http://moveit.ros.org/</url>
+  <url type="bugtracker">https://github.com/ros-planning/moveit_setup_assistant/issues</url>
+  <url type="repository">https://github.com/ros-planning/moveit_setup_assistant</url>
+
+  <run_depend>moveit_ros_move_group</run_depend>
+  <run_depend>moveit_planners_ompl</run_depend>
+  <run_depend>moveit_ros_visualization</run_depend>
+  <run_depend>joint_state_publisher</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
+  <run_depend>xacro</run_depend>
+  <run_depend>mir_hardware_config</run_depend>
+  <run_depend>youbot_arm_kinematics_moveit</run_depend>
+  <run_depend>mcr_interpolation_planner_moveit</run_depend>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  
+</package>

--- a/mir_robots/mir_bringup/robots/youbot-brsu-arm.launch
+++ b/mir_robots/mir_bringup/robots/youbot-brsu-arm.launch
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<launch>
+
+  <arg name="robot" value="$(optenv ROBOT youbot-brsu-arm)" />
+
+  <include file="$(find mir_bringup)/components/youbot_oodl_driver.launch" />
+
+  <include file="$(find mir_teleop)/ros/launch/teleop_joypad.launch">
+    <arg name="robot" value="$(arg robot)"/>
+  </include>
+
+  <include file="$(find mir_arm_cartesian_control)/ros/launch/arm_cartesian_control_youbot.launch" />	
+
+</launch>

--- a/mir_robots/mir_bringup/robots/youbot-brsu-arm.launch
+++ b/mir_robots/mir_bringup/robots/youbot-brsu-arm.launch
@@ -3,7 +3,9 @@
 
   <arg name="robot" value="$(optenv ROBOT youbot-brsu-arm)" />
 
-  <include file="$(find mir_bringup)/components/youbot_oodl_driver.launch" />
+  <include file="$(find mir_bringup)/components/youbot_oodl_driver.launch">
+    <arg name="youBotHasBase" value="false"/>
+  </include>
 
   <include file="$(find mir_teleop)/ros/launch/teleop_joypad.launch">
     <arg name="robot" value="$(arg robot)"/>

--- a/mir_robots/mir_hardware_config/youbot-brsu-arm/config/arm.yaml
+++ b/mir_robots/mir_hardware_config/youbot-brsu-arm/config/arm.yaml
@@ -1,0 +1,24 @@
+arm_controller:
+  joints:
+    - arm_joint_1
+    - arm_joint_2
+    - arm_joint_3
+    - arm_joint_4
+    - arm_joint_5
+
+  limits:
+    arm_joint_1:
+      min: 0.0100692
+      max: 5.84014
+    arm_joint_2:
+      min: 0.0100692
+      max: 2.61799
+    arm_joint_3:
+      min: -5.02655
+      max: -0.015708
+    arm_joint_4:
+      min: 0.0221239
+      max: 3.4292
+    arm_joint_5:
+      min: 0.110619
+      max: 5.64159

--- a/mir_robots/mir_hardware_config/youbot-brsu-arm/config/gripper.yaml
+++ b/mir_robots/mir_hardware_config/youbot-brsu-arm/config/gripper.yaml
@@ -1,0 +1,8 @@
+gripper_controller:
+  limits:
+    gripper_finger_joint_l:
+      min: 0.0
+      max: 0.0115
+    gripper_finger_joint_r:
+      min: 0
+      max: 0.0115

--- a/mir_robots/mir_hardware_config/youbot-brsu-arm/config/joy.yaml
+++ b/mir_robots/mir_hardware_config/youbot-brsu-arm/config/joy.yaml
@@ -1,0 +1,3 @@
+dev: /dev/input/js0
+deadzone: 0.12
+autorepeat_rate: 50.0

--- a/mir_robots/mir_hardware_config/youbot-brsu-arm/config/teleop.yaml
+++ b/mir_robots/mir_hardware_config/youbot-brsu-arm/config/teleop.yaml
@@ -1,0 +1,5 @@
+base_max_linear_x_vel: 0.3          # m per second in run mode
+base_max_linear_y_vel: 0.3          # m per second in run mode 
+base_max_angular_vel: 0.6           # rad per second in run mode 
+arm_max_vel: 0.4                    # rad per second in run mode 
+soft_joint_limit_threshold: 0.1     # rad

--- a/mir_robots/mir_hardware_config/youbot-brsu-arm/urdf/robot.urdf.xacro
+++ b/mir_robots/mir_hardware_config/youbot-brsu-arm/urdf/robot.urdf.xacro
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:xacro="http://ros.org/wiki/xacro"
+       name="youbot" >
+
+  <!-- The following included files set up definitions of parts of the robot body -->
+  <!-- misc common stuff -->
+  <xacro:include filename="$(find youbot_description)/urdf/common.xacro" />
+  <xacro:include filename="$(find mcr_description)/urdf/materials.urdf.xacro" />
+  <!-- youbot arm and gripper-->
+  <xacro:include filename="$(find youbot_description)/urdf/youbot_arm/arm.urdf.xacro"/>
+  <!-- youbot gripper -->
+  <xacro:include filename="$(find youbot_description)/urdf/youbot_gripper/gripper.urdf.xacro" />
+ 
+  
+  <!-- controller manager -->
+  <xacro:include filename="$(find youbot_description)/controller/ros_controller.urdf.xacro" />
+  <!-- materials for visualization -->
+  <xacro:include filename="$(find youbot_description)/urdf/materials.urdf.xacro" />
+
+  <!-- Now we can start using the macros included above to define the actual youbot -->
+
+  <link name="base_link" />
+  <xacro:youbot_arm name="arm" parent="base_link">
+    <origin xyz="-0.022 0.0 0.037" rpy="0 0 0" />
+  </xacro:youbot_arm>
+
+  <xacro:youbot_gripper name="gripper" parent="arm_link_5">
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </xacro:youbot_gripper>
+  
+</robot>


### PR DESCRIPTION
<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->
Bringup and moveit configurations for just a single youbot arm are added. This can be useful when one is working with youbot arm without base (or with base but does not want to use base) without changing launch files of `youbot-driver`. (Could be quite helpful for beginners who do not know the full stack...)

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

- Added moveit folder for arm
- Added bringup configurations and files such that if env variable ROBOT is `youbot-brsu-arm` then only arm will be initialised


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [ ] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
