### PR TITLE
Fixed bugs with bringup launch file for arm only

### DIFF
--- a/mir_robots/mir_bringup/components/youbot_oodl_driver.launch
+++ b/mir_robots/mir_bringup/components/youbot_oodl_driver.launch
@@ -13,8 +13,11 @@ or enable the USE_SETCAP flag in the cmake file and recompile again.
 <launch>
 
   <!-- Set relevant parameters. -->
-  <param name="youBotHasBase" type="bool" value="true"/>
-  <param name="youBotHasArms" type="bool" value="true"/> 
+  <arg name="youBotHasBase"  default="true"/>
+  <arg name="youBotHasArms"  default="true"/> 
+
+  <param name="youBotHasBase" type="bool" value="$(arg youBotHasBase)"/>
+  <param name="youBotHasArms" type="bool" value="$(arg youBotHasArms)"/> 
 
   <param name="youBotDriverCycleFrequencyInHz" type="double" value="50.0"/>
   <param name="youBotDriverGripperReadingsCycleFrequencyInHz" type="double" value="0.5" />

--- a/mir_robots/mir_bringup/robots/youbot-brsu-arm.launch
+++ b/mir_robots/mir_bringup/robots/youbot-brsu-arm.launch
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
+  <arg name="is_camera_required" default="true" />
+  <arg name="is_camera_intel" default="true" />
   <arg name="robot" value="$(optenv ROBOT youbot-brsu-arm)" />
 
   <include file="$(find mir_bringup)/components/youbot_oodl_driver.launch">


### PR DESCRIPTION
<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

- Made `youBotHasBase` and `youBotHasArms` into args so that parent launch file can change it
- Added dummy args `is_camera_required` and `is_camera_intel` so that the parent launch file does not complain

## Related PRs
Related to #71 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [ ] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
