### PR TITLE
Add support to build and deploy docker image in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: cpp
 env:
   global:
     - COMPOSE_VERSION: 1.22.0
-    - CONTAINER_RELEASE_IMAGE: bitbots/mas_industrial_robotics:$TRAVIS_BRANCH
+    - CONTAINER_RELEASE_IMAGE: bitbots/bitbots-industrial:$TRAVIS_BRANCH
 
 before_install:
   - sudo pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,29 @@
 sudo: required
 
+services:
+  - docker
+
 language: cpp
+
+env:
+  global:
+    - COMPOSE_VERSION: 1.22.0
+    - CONTAINER_RELEASE_IMAGE: bitbots/mas_industrial_robotics:$TRAVIS_BRANCH
 
 before_install:
   - sudo pip install --upgrade pip
   - sudo pip install sphinx
   - sudo pip install --user sphinx-rtd-theme
+  - sudo rm /usr/local/bin/docker-compose
+  - sudo curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+  - sudo chmod +x /usr/local/bin/docker-compose
+  - docker-compose -v
+  - echo $CONTAINER_RELEASE_IMAGE
 
 stages:
   - build
+  - name: deploy
+    if: branch IN (devel, indigo, kinetic, melodic) OR tag = true
   - name: docs
     if: (branch IN (devel, indigo, kinetic, melodic) AND type != "pull_request") OR tag = true
 
@@ -17,7 +32,15 @@ jobs:
     - stage: build
       name: "Complete Build"
       script:
-        - ./setup.sh
+        - ./setup.sh full
+    - stage: deploy
+      name: "Docker Hub Deployment"
+      skip_cleanup: true
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+        - docker-compose build travis
+        - docker images
+        - docker push $CONTAINER_RELEASE_IMAGE
     - stage: docs
       name: "Build and deploy documentation"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 stages:
   - build
   - name: deploy
-    if: branch IN (devel, indigo, kinetic, melodic) OR tag = true
+    if: (branch IN (devel, indigo, kinetic, melodic) AND type != "pull_request") OR tag = true
   - name: docs
     if: (branch IN (devel, indigo, kinetic, melodic) AND type != "pull_request") OR tag = true
 

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,0 +1,15 @@
+FROM ros:kinetic
+
+RUN apt update -qq && \
+    apt install -y -qq sudo software-properties-common
+
+WORKDIR /mas_industrial_robotics
+COPY . /mas_industrial_robotics
+
+# Set Environment variables
+ENV ROBOT=youbot-brsu-4
+ENV ROBOT_ENV=brsu-c025
+
+RUN ./setup.sh
+
+WORKDIR /

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+  travis:
+    build:
+      dockerfile: .travis/Dockerfile
+      context: .
+    image: $CONTAINER_RELEASE_IMAGE
+  mas_industrial_robotics:
+    build:
+      dockerfile: .travis/Dockerfile
+      context: .
+    image: b-it-bots/mas_industrial_robotics

--- a/repository.debs
+++ b/repository.debs
@@ -21,6 +21,8 @@ packagelist=(
     g++-multilib
     flex
     mongodb
+    librealsense2-dkms
+    librealsense2-utils
     ros-kinetic-amcl
     ros-kinetic-bfl
     ros-kinetic-brics-actuator
@@ -67,6 +69,7 @@ packagelist=(
     ros-kinetic-diagnostic-analysis
     ros-kinetic-laser-filters
     ros-kinetic-mongodb-store
+    ros-kinetic-realsense2-camera
 )
 
 ### install debian packages listed in array above

--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,8 @@ function fancy_print {
 function update_keys {
     sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu xenial main\" > /etc/apt/sources.list.d/ros-latest.list"
     sudo curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC1CF6E31E6BADE8868B172B4F42ED6FBAB17C654' | sudo apt-key add - 
+    sudo apt-key adv --keyserver keys.gnupg.net --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE
+    sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main" -u
 }
 
 function install_ros_kinetic_base {
@@ -26,16 +28,22 @@ function install_ros_kinetic_base {
 }
 
 function install_ros_dependencies {
+    sudo rm -rf /etc/ros/rosdep/sources.list.d/*
     sudo rosdep init -q
     sudo rosdep update -q
     sudo apt install -y -qq python-rosinstall python-rosinstall-generator python-wstool build-essential python-catkin-tools python-pip
     sudo pip install catkin_pkg empy
+    sudo rm -rf /var/lib/apt/lists/*
 }
 
 function install_ros {
-    fancy_print "Installing ROS"
     update_keys
-    install_ros_kinetic_base
+    if $1
+        then
+            fancy_print "Installing ROS"
+            install_ros_kinetic_base
+    fi
+    fancy_print "Installing ROS Dependencies"
     install_ros_dependencies
     source /opt/ros/kinetic/setup.bash
 }
@@ -56,8 +64,9 @@ function get_mas_industrial_robotics {
     fancy_print "Getting source code"
     cd ~/catkin_ws/src
     cp -r $ROOT_DIR ~/catkin_ws/src
-    cd mas_industrial_robotics
+    cd ~/catkin_ws/src/mas_industrial_robotics
     ./repository.debs
+    sudo rm -rf /var/lib/apt/lists/*
 }
 
 function build_mas_industrial_robotics {
@@ -65,7 +74,7 @@ function build_mas_industrial_robotics {
     source ~/catkin_ws/devel/setup.bash
     # Disable building the youbot_driver_ros_interface in travis CI as it expects a user input during build
     touch ~/catkin_ws/src/youbot_driver_ros_interface/CATKIN_IGNORE
-    catkin build 
+    catkin build
 }
 
 
@@ -73,8 +82,14 @@ function build_mas_industrial_robotics {
 # Store the root directory path in a variable
 ROOT_DIR=$(pwd)
 
+FULL_INSTALL=false
+if [ $# -eq 1 ] && [ $1 == "full" ]
+    then
+        FULL_INSTALL=true
+fi
+
 install_basic_packages
-install_ros
+install_ros $FULL_INSTALL
 setup_catkin_ws
 get_mas_industrial_robotics
 build_mas_industrial_robotics


### PR DESCRIPTION
This pull request adds support to build and deploy docker images of mas_industrial_robotics to the Docker Hub.

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* Added all resource files required to build docker images
* Update Travis config to build and deploy images for the devel, indigo, kinetic, melodic branches
* Update setup script to satisfy docker builds and install RealSense dependencies

Closes #43 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
