### PR TITLE
Base motion for perceive location and perceive mock servers

### DIFF
--- a/mir_planning/mir_actions/mir_actions/ros/launch/run_action_servers.launch
+++ b/mir_planning/mir_actions/mir_actions/ros/launch/run_action_servers.launch
@@ -15,7 +15,7 @@
     <node pkg="mir_unstage_object" type="unstage_object_server.py" name="unstage_object_server" output="screen" />
 
     <!-- perceive location action server -->
-    <node pkg="mir_perceive_location" type="perceive_location_server.py" name="perceive_location_server" output="screen" />
+    <include file="$(find mir_perceive_location)/ros/launch/perceive_location_server.launch" />
 
     <!-- wbc pick object action server -->
     <node pkg="mir_pick_object" type="pick_object_server.py" name="wbc_pick_object_server" output="screen"/>

--- a/mir_planning/mir_actions/mir_perceive_location/ros/launch/perceive_location_server.launch
+++ b/mir_planning/mir_actions/mir_perceive_location/ros/launch/perceive_location_server.launch
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<launch>
+ 
+    <arg name="base_motion_enabled" default="false" />
+
+    <node pkg="mir_perceive_location" type="perceive_location_server.py" name="perceive_location_server" output="screen">
+        <param name="base_motion_enabled" type="bool" value="$(arg base_motion_enabled)" />
+    </node>
+</launch>

--- a/mir_planning/mir_actions/mir_perceive_location/ros/scripts/perceive_location_server.py
+++ b/mir_planning/mir_actions/mir_perceive_location/ros/scripts/perceive_location_server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import tf
 import rospy
 import smach
 
@@ -14,6 +15,7 @@ from mir_actions.utils import Utils
 from mir_planning_msgs.msg import GenericExecuteAction, GenericExecuteResult, GenericExecuteFeedback
 from diagnostic_msgs.msg import KeyValue
 
+from geometry_msgs.msg import PoseStamped, Quaternion
 # perception object list
 from mas_perception_msgs.msg import ObjectList
 
@@ -36,14 +38,46 @@ class SetupMoveArm(smach.State):
 
 #===============================================================================
 
+class SetupMoveBaseWithDBC(smach.State):
+    def __init__(self):
+        smach.State.__init__(self, outcomes=['pose_set','tried_all'],
+                                   input_keys=['base_pose_index', 'base_pose_list', 'arm_pose_list', 'arm_pose_index'],
+                                   output_keys=['base_pose_index', 'move_arm_to'])
+        self._dbc_pose_pub = rospy.Publisher('/mcr_navigation/direct_base_controller/input_pose',
+                                             PoseStamped, queue_size=10)
+        rospy.sleep(0.1) # time for the publisher to register in ros network
+
+    def execute(self, userdata):
+        if userdata.base_pose_index >= len(userdata.base_pose_list):
+            return 'tried_all'
+
+        target_pose_dict = userdata.base_pose_list[userdata.base_pose_index]
+        # set base pose to next pose in list
+        dbc_pose = PoseStamped()
+        dbc_pose.header.stamp = rospy.Time.now()
+        dbc_pose.header.frame_id = 'base_link_static'
+        dbc_pose.pose.position.x = target_pose_dict['x']
+        dbc_pose.pose.position.y = target_pose_dict['y']
+        quat = tf.transformations.quaternion_from_euler(0.0, 0.0, target_pose_dict['theta'])
+        dbc_pose.pose.orientation = Quaternion(*quat)
+
+        userdata.base_pose_index += 1
+        print(dbc_pose)
+        self._dbc_pose_pub.publish(dbc_pose)
+        userdata.move_arm_to = userdata.arm_pose_list[userdata.arm_pose_index]
+        return 'pose_set'
+
+#===============================================================================
+
 class Setup(smach.State):
     def __init__(self):
         smach.State.__init__(self, outcomes=['succeeded'],
                                    input_keys=[],
-                                   output_keys=['feedback', 'result', 'arm_pose_index'])
+                                   output_keys=['feedback', 'result', 'arm_pose_index', 'base_pose_index'])
 
     def execute(self, userdata):
         userdata.arm_pose_index = 0 # reset arm position for new request
+        userdata.base_pose_index = 0 # reset base position for new request
 
         # Add empty result msg (because if none of the state do it, action server gives error)
         userdata.result = GenericExecuteResult()
@@ -78,6 +112,16 @@ class PopulateResultWithObjects(smach.State):
 
 #===============================================================================
 
+class GetMotionType(smach.State):
+    def __init__(self):
+        smach.State.__init__(self, outcomes=['base_motion', 'arm_motion'])
+
+    def execute(self, userdata):
+        base_motion_enabled = rospy.get_param('~base_motion_enabled', False)
+        return 'base_motion' if base_motion_enabled else 'arm_motion'
+
+#===============================================================================
+
 def main():
     rospy.init_node('perceive_location_server')
     sleep_time = rospy.get_param('~sleep_time', 1.0)
@@ -91,6 +135,15 @@ def main():
                                  'look_at_workspace_from_near_left',
                                  'look_at_workspace_from_near_right']
     sm.userdata.arm_pose_index = 0
+
+    base_x_offset = rospy.get_param('~base_x_offset', 0.0)
+    base_y_offset = rospy.get_param('~base_y_offset', 0.25)
+    base_theta_offset = rospy.get_param('~base_theta_offset', 0.0)
+    sm.userdata.base_pose_list = [{'x': 0.0, 'y': 0.0, 'theta': 0.0},
+                                  {'x': base_x_offset, 'y': base_y_offset, 'theta': base_theta_offset},
+                                  {'x': base_x_offset, 'y': -base_y_offset, 'theta': -base_theta_offset}]
+    sm.userdata.base_pose_index = 0
+
     with sm:
         # approach to platform
         smach.StateMachine.add('SETUP', Setup(),
@@ -99,16 +152,42 @@ def main():
         # publish a static frame which will be used as reference for perceived objs
         smach.StateMachine.add('PUBLISH_REFERENCE_FRAME', gbs.send_event
                 ([('/static_transform_publisher_node/event_in', 'e_start')]),
-                transitions={'success':'START_OBJECT_LIST_MERGER'})
+                transitions={'success':'SET_DBC_PARAMS'})
+
+        # publish a static frame which will be used as reference for perceived objs
+        smach.StateMachine.add(
+                'SET_DBC_PARAMS',
+                gbs.set_named_config('dbc_pick_object'),
+                transitions={'success': 'START_OBJECT_LIST_MERGER',
+                             'timeout': 'OVERALL_FAILED',
+                             'failure': 'OVERALL_FAILED'})
 
         smach.StateMachine.add('START_OBJECT_LIST_MERGER', gbs.send_and_wait_events_combined(
                 event_in_list=[('/mcr_perception/object_list_merger/event_in', 'e_start'),
                                ('/mcr_perception/object_selector/event_in', 'e_start')],
                 event_out_list=[('/mcr_perception/object_list_merger/event_out', 'e_started', True)],
                 timeout_duration=5),
-                transitions={'success': 'SET_APPROPRIATE_ARM_POSE',
+                transitions={'success': 'GET_MOTION_TYPE',
                              'timeout': 'OVERALL_FAILED',
                              'failure': 'OVERALL_FAILED'})
+
+        smach.StateMachine.add('GET_MOTION_TYPE', GetMotionType(),
+                transitions={'base_motion': 'SET_APPROPRIATE_BASE_POSE',
+                             'arm_motion': 'SET_APPROPRIATE_ARM_POSE'})
+
+        smach.StateMachine.add('SET_APPROPRIATE_BASE_POSE', SetupMoveBaseWithDBC(),
+                transitions={'pose_set': 'MOVE_BASE_WITH_DBC',
+                             'tried_all': 'POPULATE_RESULT_WITH_OBJECTS'})
+
+        smach.StateMachine.add(
+                'MOVE_BASE_WITH_DBC',
+                gbs.send_and_wait_events_combined(
+                    event_in_list=[('/mcr_navigation/direct_base_controller/coordinator/event_in','e_start')],
+                    event_out_list=[('/mcr_navigation/direct_base_controller/coordinator/event_out','e_success', True)],
+                    timeout_duration=10),
+                transitions={'success': 'MOVE_ARM',
+                             'timeout': 'STOP_DBC',
+                             'failure': 'STOP_DBC'})
 
         smach.StateMachine.add('SET_APPROPRIATE_ARM_POSE', SetupMoveArm(),
                 transitions={'pose_set': 'MOVE_ARM',
@@ -159,11 +238,21 @@ def main():
                 timeout_duration=10.0),
                 transitions={'success': 'POPULATE_RESULT_WITH_OBJECTS',
                              'timeout': 'OVERALL_FAILED',
-                             'failure': 'SET_APPROPRIATE_ARM_POSE'})
+                             'failure': 'GET_MOTION_TYPE'})
 
         # populate action server result with perceived objects
         smach.StateMachine.add('POPULATE_RESULT_WITH_OBJECTS', PopulateResultWithObjects(), 
                 transitions={'succeeded':'OVERALL_SUCCESS'})
+
+        smach.StateMachine.add(
+                'STOP_DBC',
+                gbs.send_and_wait_events_combined(
+                    event_in_list=[('/mcr_navigation/direct_base_controller/coordinator/event_in','e_stop')],
+                    event_out_list=[('/mcr_navigation/direct_base_controller/coordinator/event_out','e_stopped', True)],
+                    timeout_duration=10),
+                transitions={'success': 'OVERALL_FAILED',
+                             'timeout': 'OVERALL_FAILED',
+                             'failure': 'OVERALL_FAILED'})
 
     # smach viewer
     if rospy.get_param('~viewer_enabled', False):

--- a/mir_planning/mir_actions/mir_perceive_location/ros/scripts/perceive_location_server.py
+++ b/mir_planning/mir_actions/mir_perceive_location/ros/scripts/perceive_location_server.py
@@ -44,7 +44,7 @@ class SetupMoveBaseWithDBC(smach.State):
                                    input_keys=['base_pose_index', 'base_pose_list', 'arm_pose_list', 'arm_pose_index'],
                                    output_keys=['base_pose_index', 'move_arm_to'])
         self._dbc_pose_pub = rospy.Publisher('/mcr_navigation/direct_base_controller/input_pose',
-                                             PoseStamped, queue_size=10)
+                                             PoseStamped, queue_size=1)
         rospy.sleep(0.1) # time for the publisher to register in ros network
 
     def execute(self, userdata):

--- a/mir_planning/mir_actions/mir_perceive_mock/ros/launch/perceive_aruco_server.launch
+++ b/mir_planning/mir_actions/mir_perceive_mock/ros/launch/perceive_aruco_server.launch
@@ -2,11 +2,14 @@
 <launch>
  
     <arg name="static_transform_frame" default="base_link_static" />
+    <arg name="base_motion_enabled" default="false" />
 
     <include file="$(find mir_perceive_aruco_cube)/ros/launch/perceive_aruco_cube.launch" >
       <arg name="target_frame" value="$(arg static_transform_frame)" />
     </include>
     
 
-    <node pkg="mir_perceive_mock" type="perceive_aruco_server" name="perceive_aruco_server" output="screen" />
+    <node pkg="mir_perceive_mock" type="perceive_aruco_server" name="perceive_aruco_server" output="screen">
+        <param name="base_motion_enabled" type="bool" value="$(arg base_motion_enabled)" />
+    </node>
 </launch>

--- a/mir_planning/mir_actions/mir_perceive_mock/ros/scripts/perceive_aruco_server
+++ b/mir_planning/mir_actions/mir_perceive_mock/ros/scripts/perceive_aruco_server
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import tf
 import rospy
 import smach
 
@@ -14,6 +15,7 @@ from mir_planning_msgs.msg import GenericExecuteAction, GenericExecuteResult, Ge
 from diagnostic_msgs.msg import KeyValue
 
 # perception object list
+from geometry_msgs.msg import PoseStamped, Quaternion
 from mas_perception_msgs.msg import ObjectList
 
 #===============================================================================
@@ -35,14 +37,46 @@ class SetupMoveArm(smach.State):
 
 #===============================================================================
 
+class SetupMoveBaseWithDBC(smach.State):
+    def __init__(self):
+        smach.State.__init__(self, outcomes=['pose_set','tried_all'],
+                                   input_keys=['base_pose_index', 'base_pose_list', 'arm_pose_list', 'arm_pose_index'],
+                                   output_keys=['base_pose_index', 'move_arm_to'])
+        self._dbc_pose_pub = rospy.Publisher('/mcr_navigation/direct_base_controller/input_pose',
+                                             PoseStamped, queue_size=10)
+        rospy.sleep(0.1) # time for the publisher to register in ros network
+
+    def execute(self, userdata):
+        if userdata.base_pose_index >= len(userdata.base_pose_list):
+            return 'tried_all'
+
+        target_pose_dict = userdata.base_pose_list[userdata.base_pose_index]
+        # set base pose to next pose in list
+        dbc_pose = PoseStamped()
+        dbc_pose.header.stamp = rospy.Time.now()
+        dbc_pose.header.frame_id = 'base_link_static'
+        dbc_pose.pose.position.x = target_pose_dict['x']
+        dbc_pose.pose.position.y = target_pose_dict['y']
+        quat = tf.transformations.quaternion_from_euler(0.0, 0.0, target_pose_dict['theta'])
+        dbc_pose.pose.orientation = Quaternion(*quat)
+
+        userdata.base_pose_index += 1
+        print(dbc_pose)
+        self._dbc_pose_pub.publish(dbc_pose)
+        userdata.move_arm_to = userdata.arm_pose_list[userdata.arm_pose_index]
+        return 'pose_set'
+
+#===============================================================================
+
 class Setup(smach.State):
     def __init__(self):
         smach.State.__init__(self, outcomes=['succeeded'],
                                    input_keys=[],
-                                   output_keys=['feedback', 'result', 'arm_pose_index'])
+                                   output_keys=['feedback', 'result', 'arm_pose_index', 'base_pose_index'])
 
     def execute(self, userdata):
         userdata.arm_pose_index = 0 # reset arm position for new request
+        userdata.base_pose_index = 0 # reset arm position for new request
 
         # Add empty result msg (because if none of the state do it, action server gives error)
         userdata.result = GenericExecuteResult()
@@ -77,6 +111,16 @@ class PopulateResultWithObjects(smach.State):
 
 #===============================================================================
 
+class GetMotionType(smach.State):
+    def __init__(self):
+        smach.State.__init__(self, outcomes=['base_motion', 'arm_motion'])
+
+    def execute(self, userdata):
+        base_motion_enabled = rospy.get_param('~base_motion_enabled', False)
+        return 'base_motion' if base_motion_enabled else 'arm_motion'
+
+#===============================================================================
+
 def main():
     rospy.init_node('perceive_aruco_server')
 
@@ -92,6 +136,14 @@ def main():
                                  'look_at_workspace_from_near_right']
     sm.userdata.arm_pose_index = 0
 
+    base_x_offset = rospy.get_param('~base_x_offset', 0.0)
+    base_y_offset = rospy.get_param('~base_y_offset', 0.25)
+    base_theta_offset = rospy.get_param('~base_theta_offset', 0.0)
+    sm.userdata.base_pose_list = [{'x': 0.0, 'y': 0.0, 'theta': 0.0},
+                                  {'x': base_x_offset, 'y': base_y_offset, 'theta': base_theta_offset},
+                                  {'x': base_x_offset, 'y': -base_y_offset, 'theta': -base_theta_offset}]
+    sm.userdata.base_pose_index = 0
+
     with sm:
         # setup the server's internal state
         smach.StateMachine.add('SETUP', Setup(),
@@ -100,7 +152,33 @@ def main():
         # publish a static frame which will be used as reference for perceived objs
         smach.StateMachine.add('PUBLISH_REFERENCE_FRAME', gbs.send_event
                 ([('/static_transform_publisher_node/event_in', 'e_start')]),
-                transitions={'success':'SET_APPROPRIATE_ARM_POSE'})
+                transitions={'success':'SET_DBC_PARAMS'})
+
+        # publish a static frame which will be used as reference for perceived objs
+        smach.StateMachine.add(
+                'SET_DBC_PARAMS',
+                gbs.set_named_config('dbc_pick_object'),
+                transitions={'success': 'GET_MOTION_TYPE',
+                             'timeout': 'OVERALL_FAILED',
+                             'failure': 'OVERALL_FAILED'})
+
+        smach.StateMachine.add('GET_MOTION_TYPE', GetMotionType(),
+                transitions={'base_motion': 'SET_APPROPRIATE_BASE_POSE',
+                             'arm_motion': 'SET_APPROPRIATE_ARM_POSE'})
+
+        smach.StateMachine.add('SET_APPROPRIATE_BASE_POSE', SetupMoveBaseWithDBC(),
+                transitions={'pose_set': 'MOVE_BASE_WITH_DBC',
+                             'tried_all': 'POPULATE_RESULT_WITH_OBJECTS'})
+
+        smach.StateMachine.add(
+                'MOVE_BASE_WITH_DBC',
+                gbs.send_and_wait_events_combined(
+                    event_in_list=[('/mcr_navigation/direct_base_controller/coordinator/event_in','e_start')],
+                    event_out_list=[('/mcr_navigation/direct_base_controller/coordinator/event_out','e_success', True)],
+                    timeout_duration=10),
+                transitions={'success': 'MOVE_ARM',
+                             'timeout': 'STOP_DBC',
+                             'failure': 'STOP_DBC'})
 
         smach.StateMachine.add('SET_APPROPRIATE_ARM_POSE', SetupMoveArm(),
                 transitions={'pose_set': 'MOVE_ARM',
@@ -118,11 +196,22 @@ def main():
                 timeout_duration=10),
                 transitions={'success': 'POPULATE_RESULT_WITH_OBJECTS',
                              'timeout': 'OVERALL_FAILED',
-                             'failure': 'SET_APPROPRIATE_ARM_POSE'})
+                             'failure': 'GET_MOTION_TYPE'})
          
         # populate action server result with perceived objects
         smach.StateMachine.add('POPULATE_RESULT_WITH_OBJECTS', PopulateResultWithObjects(), 
                 transitions={'succeeded':'OVERALL_SUCCESS'})
+
+        smach.StateMachine.add(
+                'STOP_DBC',
+                gbs.send_and_wait_events_combined(
+                    event_in_list=[('/mcr_navigation/direct_base_controller/coordinator/event_in','e_stop')],
+                    event_out_list=[('/mcr_navigation/direct_base_controller/coordinator/event_out','e_stopped', True)],
+                    timeout_duration=10),
+                transitions={'success': 'OVERALL_FAILED',
+                             'timeout': 'OVERALL_FAILED',
+                             'failure': 'OVERALL_FAILED'})
+
 
     # smach viewer
     if rospy.get_param('~viewer_enabled', False):

--- a/mir_planning/mir_actions/mir_perceive_mock/ros/scripts/perceive_aruco_server
+++ b/mir_planning/mir_actions/mir_perceive_mock/ros/scripts/perceive_aruco_server
@@ -43,7 +43,7 @@ class SetupMoveBaseWithDBC(smach.State):
                                    input_keys=['base_pose_index', 'base_pose_list', 'arm_pose_list', 'arm_pose_index'],
                                    output_keys=['base_pose_index', 'move_arm_to'])
         self._dbc_pose_pub = rospy.Publisher('/mcr_navigation/direct_base_controller/input_pose',
-                                             PoseStamped, queue_size=10)
+                                             PoseStamped, queue_size=1)
         rospy.sleep(0.1) # time for the publisher to register in ros network
 
     def execute(self, userdata):

--- a/mir_planning/mir_actions/mir_perceive_mock/ros/scripts/perceive_aruco_server
+++ b/mir_planning/mir_actions/mir_perceive_mock/ros/scripts/perceive_aruco_server
@@ -14,8 +14,8 @@ from mir_actions.utils import Utils
 from mir_planning_msgs.msg import GenericExecuteAction, GenericExecuteResult, GenericExecuteFeedback
 from diagnostic_msgs.msg import KeyValue
 
-# perception object list
 from geometry_msgs.msg import PoseStamped, Quaternion
+# perception object list
 from mas_perception_msgs.msg import ObjectList
 
 #===============================================================================
@@ -76,7 +76,7 @@ class Setup(smach.State):
 
     def execute(self, userdata):
         userdata.arm_pose_index = 0 # reset arm position for new request
-        userdata.base_pose_index = 0 # reset arm position for new request
+        userdata.base_pose_index = 0 # reset base position for new request
 
         # Add empty result msg (because if none of the state do it, action server gives error)
         userdata.result = GenericExecuteResult()


### PR DESCRIPTION
<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->

## Changelog
- Perceive location and perceive mock server can now be configured to move base instead of arm when desired object is not found.
- As it can be configured with ros param, the behaviour can be changed without relaunching the server. (just set `perceive_location_server/base_motion_enabled`)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
