### PR TITLE
Modified setup.sh to accept user-specific catkin_ws parent directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 *~
 html/
 latex/
+
+.vscode/

--- a/README.md
+++ b/README.md
@@ -59,18 +59,18 @@ First of all you have to clone the repository.
 
 Navigate into the cloned repository and run setup.sh file.
 
-     ./setup.sh
+     ./setup.sh <optional arg for catkin_ws parent dir>
 
 This script does the following,
 
 * installs ROS, if not previously installed
-* creates a catkin workspace directory in ~/catkin_ws (if it does not exist)
-* copies the clone of the mas_industiral_robotics from your ~/temp to ~/catkin_ws/src and installs the necessary ros dependencies and other related repositories
+* creates a catkin workspace folder in the directory specified in the argument or by default places it in home directory, i.e. ~/catkin_ws (if it does not exist)
+* copies the clone of the mas_industiral_robotics from your ~/temp to \<your folder\>/catkin_ws/src and installs the necessary ros dependencies and other related repositories
 * initiates a catkin build in the catkin workspace
 
 Add the following to your bashrc and source your bashrc, so that you need not execute ./setup.sh script each time you open your terminal
 
-     source ~/catkin_ws/devel/setup.bash
+     source <your folder>/catkin_ws/devel/setup.bash
 
 If no errors appear everything is ready to use. Great job!
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ First of all you have to clone the repository.
 
 Navigate into the cloned repository and run setup.sh file.
 
-     ./setup.sh <optional arg for catkin_ws parent dir>
+     ./setup.sh full <optional arg for catkin_ws parent dir>
 
 This script does the following,
 
-* installs ROS, if not previously installed
+* installs ROS, if not previously installed, provided the optional argument full is given
 * creates a catkin workspace folder in the directory specified in the argument or by default places it in home directory, i.e. ~/catkin_ws (if it does not exist)
 * copies the clone of the mas_industiral_robotics from your ~/temp to \<your folder\>/catkin_ws/src and installs the necessary ros dependencies and other related repositories
 * initiates a catkin build in the catkin workspace

--- a/setup.sh
+++ b/setup.sh
@@ -94,7 +94,7 @@ if [ -z "$2" ]
     then
         INSTALL_DIR=~
     else
-        INSTALL_DIR=$1
+        INSTALL_DIR=$2
 fi
 
 install_basic_packages

--- a/setup.sh
+++ b/setup.sh
@@ -51,29 +51,29 @@ function install_ros {
 # Setup catkin workspace in the home directory
 function setup_catkin_ws {
     fancy_print "Setting up a catkin workspace"
-    mkdir -p ~/catkin_ws/src
-    cd ~/catkin_ws
+    mkdir -p $INSTALL_DIR/catkin_ws/src
+    cd $INSTALL_DIR/catkin_ws
     catkin init
     catkin config --extend /opt/ros/kinetic/
     catkin build
-    source ~/catkin_ws/devel/setup.bash
+    source $INSTALL_DIR/catkin_ws/devel/setup.bash
 }
 
 # Clone and install mas_industrial_robotics and all related dependencies
 function get_mas_industrial_robotics {
     fancy_print "Getting source code"
-    cd ~/catkin_ws/src
-    cp -r $ROOT_DIR ~/catkin_ws/src
-    cd ~/catkin_ws/src/mas_industrial_robotics
+    cd $INSTALL_DIR/catkin_ws/src
+    cp -r $ROOT_DIR $INSTALL_DIR/catkin_ws/src
+    cd $INSTALL_DIR/catkin_ws/src/mas_industrial_robotics
     ./repository.debs
     sudo rm -rf /var/lib/apt/lists/*
 }
 
 function build_mas_industrial_robotics {
     fancy_print "Building ROS packages"
-    source ~/catkin_ws/devel/setup.bash
+    source $INSTALL_DIR/catkin_ws/devel/setup.bash
     # Disable building the youbot_driver_ros_interface in travis CI as it expects a user input during build
-    touch ~/catkin_ws/src/youbot_driver_ros_interface/CATKIN_IGNORE
+    touch $INSTALL_DIR/catkin_ws/src/youbot_driver_ros_interface/CATKIN_IGNORE
     catkin build
 }
 
@@ -86,6 +86,15 @@ FULL_INSTALL=false
 if [ $# -eq 1 ] && [ $1 == "full" ]
     then
         FULL_INSTALL=true
+fi
+
+# If no arg then catkin_ws is created in home
+# folder, otherwise in specified folder
+if [ -z "$1" ]
+    then
+        INSTALL_DIR=~
+    else
+        INSTALL_DIR=$1
 fi
 
 install_basic_packages

--- a/setup.sh
+++ b/setup.sh
@@ -90,7 +90,7 @@ fi
 
 # If no arg then catkin_ws is created in home
 # folder, otherwise in specified folder
-if [ -z "$1" ]
+if [ -z "$2" ]
     then
         INSTALL_DIR=~
     else


### PR DESCRIPTION
Updated readme with args for running ./setup.sh

Currently, setup.sh by default creates the catkin workspace in the home directory. setup.sh is modified to take an argument which is the desired directory where the catkin workspace is created. If no argument is provided, then the catkin workspace is by default created in the home folder.

Related to #92 #109 

## Checklist:
- [x] I have updated the documentation accordingly.
