### PR TITLE
Fixed catkin build errors while setting up Youbot-3

### DIFF
--- a/mir_manipulation/mir_grasp_monitors/CMakeLists.txt
+++ b/mir_manipulation/mir_grasp_monitors/CMakeLists.txt
@@ -6,7 +6,6 @@ find_package(catkin REQUIRED
     dynamixel_msgs
     roscpp
     std_msgs
-    serial
 )
 
 catkin_package(
@@ -16,7 +15,6 @@ catkin_package(
     rospy
     sensor_msgs
     std_msgs
-    serial
 )
 
 include_directories(

--- a/repository.debs
+++ b/repository.debs
@@ -15,45 +15,45 @@ packagelist=(
     python-rosinstall
     python-setuptools
     python-zmq
-    ros-kinetic-amcl
-    ros-kinetic-clear-costmap-recovery
-    ros-kinetic-cob-scan-unifier
-    ros-kinetic-cob-srvs
-    ros-kinetic-dwa-local-planner
-    ros-kinetic-dynamixel-controllers
-    ros-kinetic-dynamixel-msgs
-    ros-kinetic-eband-local-planner
-    ros-kinetic-gazebo-ros-control
-    ros-kinetic-gazebo-plugins
-    ros-kinetic-gmapping
-    ros-kinetic-urg-node
-    ros-kinetic-joint-state-controller
-    ros-kinetic-joy
-    ros-kinetic-serial
-    ros-kinetic-map-server
-    ros-kinetic-move-base
-    ros-kinetic-moveit-core
-    ros-kinetic-moveit-commander
-    ros-kinetic-moveit-msgs
-    ros-kinetic-moveit-planners
-    ros-kinetic-moveit-ros-move-group
-    ros-kinetic-moveit-setup-assistant
-    ros-kinetic-moveit-simple-controller-manager
-    ros-kinetic-openni-launch
-    ros-kinetic-openni2-launch
-    ros-kinetic-pr2-dashboard-aggregator
-    ros-kinetic-pr2-description
-    ros-kinetic-pr2-msgs
-    ros-kinetic-ros
-    ros-kinetic-ros-controllers
-    ros-kinetic-roslint
-    ros-kinetic-rqt-robot-dashboard
-    ros-kinetic-serial
-    ros-kinetic-smach
-    ros-kinetic-srdfdom
-    ros-kinetic-twist-mux
-    ros-kinetic-usb-cam
-    ros-kinetic-global-planner
+    ros-melodic-amcl
+    ros-melodic-kinetic-clear-costmap-recovery
+    ros-melodic-cob-scan-unifier
+    ros-melodic-cob-srvs
+    ros-melodic-dwa-local-planner
+    ros-melodic-dynamixel-controllers
+    ros-melodic-dynamixel-msgs
+    ros-melodic-eband-local-planner
+    ros-melodic-gazebo-ros-control
+    ros-melodic-gazebo-plugins
+    ros-melodic-gmapping
+    ros-melodic-urg-node
+    ros-melodic-joint-state-controller
+    ros-melodic-joy
+    ros-melodic-serial
+    ros-melodic-map-server
+    ros-melodic-move-base
+    ros-melodic-moveit-core
+    ros-melodic-moveit-commander
+    ros-melodic-moveit-msgs
+    ros-melodic-moveit-planners
+    ros-melodic-moveit-ros-move-group
+    ros-melodic-moveit-setup-assistant
+    ros-melodic-moveit-simple-controller-manager
+    ros-melodic-openni-launch
+    ros-melodic-openni2-launch
+    ros-melodic-pr2-dashboard-aggregator
+    ros-melodic-pr2-description
+    ros-melodic-pr2-msgs
+    ros-melodic-ros
+    ros-melodic-ros-controllers
+    ros-melodic-roslint
+    ros-melodic-rqt-robot-dashboard
+    ros-melodic-serial
+    ros-melodic-smach
+    ros-melodic-srdfdom
+    ros-melodic-twist-mux
+    ros-melodic-usb-cam
+    ros-melodic-global-planner
 )
 
 ### install debian packages listed in array above
@@ -63,7 +63,7 @@ if [ $INSTALL_PACKAGES != false ]; then
 fi
 
 ### install further repositories
-rosinstall .. /opt/ros/kinetic repository.rosinstall
+rosinstall .. /opt/ros/melodic repository.rosinstall
 
 ### install dependencies of BRSU repositories
 dependent_repositories=$(grep -r "local-name:" repository.rosinstall  | cut -d":" -f 2 | sed -r 's/\s+//g')

--- a/repository.debs
+++ b/repository.debs
@@ -16,7 +16,7 @@ packagelist=(
     python-setuptools
     python-zmq
     ros-melodic-amcl
-    ros-melodic-kinetic-clear-costmap-recovery
+    ros-melodic-clear-costmap-recovery
     ros-melodic-cob-scan-unifier
     ros-melodic-cob-srvs
     ros-melodic-dwa-local-planner
@@ -29,7 +29,6 @@ packagelist=(
     ros-melodic-urg-node
     ros-melodic-joint-state-controller
     ros-melodic-joy
-    ros-melodic-serial
     ros-melodic-map-server
     ros-melodic-move-base
     ros-melodic-moveit-core
@@ -48,7 +47,6 @@ packagelist=(
     ros-melodic-ros-controllers
     ros-melodic-roslint
     ros-melodic-rqt-robot-dashboard
-    ros-melodic-serial
     ros-melodic-smach
     ros-melodic-srdfdom
     ros-melodic-twist-mux

--- a/repository.rosinstall
+++ b/repository.rosinstall
@@ -1,7 +1,7 @@
 - git:
     local-name: mas_common_robotics
     uri: git@github.com:b-it-bots/mas_common_robotics.git
-    version: kinetic
+    version: melodic
 
 - git:
     local-name: youbot_driver

--- a/repository.rosinstall
+++ b/repository.rosinstall
@@ -41,4 +41,4 @@
 - git:
     local-name: unmerged_packages_for_testing
     uri: git@github.com:b-it-bots/unmerged_packages_for_testing.git
-    version: kinetic
+    version: melodic


### PR DESCRIPTION
Fixed catkin build and bringup errors while setting up Youbot-3. Post these changes mapping and navigation works on youbot-3 (base only).

## Changelog
* Modified yaml files in mir_2dnav to resolve /map warnings
* Modified robot.launch for running bringup in youbot-3(only base) without errors
* Added missing yaml files for hokuyo in youbot-3 hardware config
* Updated installation files for melodic


## Checklist:
- [x ] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)


<!-- Click on the preview button to make sure everything is correctly formatted -->
