### PR TITLE
Modified files for testing code in youbot simulation

### DIFF
--- a/mir_simulation/mir_bringup_sim/robot.launch
+++ b/mir_simulation/mir_bringup_sim/robot.launch
@@ -43,6 +43,20 @@
     <param name="publish_frequency" type="double" value="100.0" />
   </node>
 
+  <!-- moveit! -->
+  <include file="$(find mir_moveit_youbot)/$(arg robot)/move_group.launch">
+      <arg name="planner_pipeline" value="interpolation" />
+  </include>
+  <param name="/move_group/trajectory_execution/allowed_execution_duration_scaling" type="double" value="1.5"/>
+  <!-- by setting this parameter we disable checking that the first point in the trajectory is the current state -->
+  <param name="/move_group/trajectory_execution/allowed_start_tolerance" type="double" value="0.0"/>
+
+  <include file="$(find mir_moveit_client)/ros/launch/moveit_client.launch" />
+
+  <!-- launching navigation nodes -->
+   <!-- move_base with dwa approach -->
+   <include file="$(find mir_2dnav)/ros/launch/2dnav.launch" />
+
   <!-- load robot specific launch files -->
   <include file="$(find mir_bringup_sim)/robots/$(arg robot).launch" />
 

--- a/repository.debs
+++ b/repository.debs
@@ -63,6 +63,7 @@ packagelist=(
     ros-kinetic-rqt-robot-dashboard
     ros-kinetic-serial
     ros-kinetic-smach
+    ros-kinetic-smach-ros
     ros-kinetic-srdfdom
     ros-kinetic-twist-mux
     ros-kinetic-usb-cam


### PR DESCRIPTION
moveit and 2dnav nodes are launched during simulation
smach-ros pkg is added for automatic installation inside docker

Moveit and 2dnav nodes are automatically launched while launching mir_bringup_sim robot.launch

## Changelog
* Added move_group, moveit_client and 2dnav launch files to robot.launch
* Added smach-ros pkg in the installation script required for launching different server nodes during testing in simulation (in docker image)

## Checklist:
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)

<!-- Click on the preview button to make sure everything is correctly formatted -->
