### PR TITLE
Fix errors in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,12 @@ jobs:
     - stage: build
       name: "Complete Build"
       script:
-        - ./setup.sh
+        - docker-compose build travis
     - stage: deploy
       name: "Docker Hub Deployment"
       skip_cleanup: true
       script:
         - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-        - docker-compose build travis
         - docker images
         - docker push $CONTAINER_RELEASE_IMAGE
     - stage: docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     - stage: build
       name: "Complete Build"
       script:
-        - ./setup.sh full
+        - ./setup.sh
     - stage: deploy
       name: "Docker Hub Deployment"
       skip_cleanup: true

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,7 +1,8 @@
 FROM ros:kinetic
 
 RUN apt update -qq && \
-    apt install -y -qq sudo software-properties-common
+    apt install -y -qq sudo software-properties-common && \
+    apt install -y -qq gcc-multilib g++-multilib
 
 WORKDIR /mas_industrial_robotics
 COPY . /mas_industrial_robotics

--- a/setup.sh
+++ b/setup.sh
@@ -89,7 +89,7 @@ function build_mas_industrial_robotics {
 ROOT_DIR=$(pwd)
 
 FULL_INSTALL=false
-if [ $# -le 2 ] && [ $1 == "full" ]
+if [[ $1 = "full" ]]
     then
         FULL_INSTALL=true
 fi


### PR DESCRIPTION
Travis build continues to fail because of missing packages. Travis.yml is modified to prevent build happening directly in travis instance. The build will now directly take place inside the docker container spawned up in the travis instance, which prevents errors in the build environment due to missing packages.

## Changelog
* setup.sh
* travis.yml
* dockerfile

## Related PRs

Related to #122 

## Checklist:
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.
