### PR TITLE
Fix for failing travis build due to deployment failure in docker hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,12 @@ jobs:
       name: "Complete Build"
       script:
         - docker-compose build travis
+      workspaces:
+        create:
+          name: build_workspace
     - stage: deploy
+      workspaces:
+        use: build_workspace
       name: "Docker Hub Deployment"
       skip_cleanup: true
       script:


### PR DESCRIPTION
docker images built in the build stage is not shared to the deployment stage 

## Changelog
* travis.yml

## Related PRs
Related to #122 #123 

## Checklist:
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.
