### PR TITLE
Feature/perception

### DIFF
--- a/mir_perception/mir_object_segmentation/ros/config/SceneSegmentation.cfg
+++ b/mir_perception/mir_object_segmentation/ros/config/SceneSegmentation.cfg
@@ -46,6 +46,9 @@ pc_os_cluster.add ("cluster_min_height", double_t, 0, "The minimum height of the
 pc_os_cluster.add ("cluster_max_height", double_t, 0, "The maximum height of the cluster above the given polygon", 0.09, 0, 5.0)
 pc_os_cluster.add ("cluster_max_length", double_t, 0, "The maximum length of the cluster", 0.25, 0, 5.0)
 pc_os_cluster.add ("cluster_min_distance_to_polygon", double_t, 0, "The minimum height of the cluster above the given polygon", 0.04, 0, 5.0)
+pc_os_cluster.add ("center_cluster", bool_t,  0, "Center cluster",  True)
+pc_os_cluster.add ("pad_cluster", bool_t,  0, "Pad cluster so that it has the same size",  False)
+pc_os_cluster.add ("padded_cluster_size", int_t, 0, "The size of the padded cluster", 2048, 128, 4096)
 
 object_pose = gen.add_group("Object pose")
 object_pose.add ("object_height_above_workspace", double_t, 0, "The height of the object above the workspace", 0.052, 0, 2.0)

--- a/mir_perception/mir_object_segmentation/ros/config/scene_segmentation_constraints.yaml
+++ b/mir_perception/mir_object_segmentation/ros/config/scene_segmentation_constraints.yaml
@@ -30,5 +30,8 @@ scene_segmentation:
     cluster_max_height: 0.09
     cluster_max_length: 0.25
     cluster_min_distance_to_polygon: 0.04
+    center_cluster: True
+    pad_cluster: False
+    padded_cluster_size: 2048
     octree_resolution: 0.0025
     object_height_above_workspace: 0.052

--- a/mir_perception/mir_object_segmentation/ros/include/mir_object_segmentation/scene_segmentation_node.h
+++ b/mir_perception/mir_object_segmentation/ros/include/mir_object_segmentation/scene_segmentation_node.h
@@ -84,6 +84,11 @@ class SceneSegmentationNode
         double octree_resolution_;
         double object_height_above_workspace_;
 
+        //cluster
+        bool center_cluster_;
+        bool pad_cluster_;
+        unsigned int padded_cluster_size_;
+
     private:
         void pointcloudCallback(const sensor_msgs::PointCloud2::Ptr &msg);
         void eventCallback(const std_msgs::String::ConstPtr &msg);

--- a/mir_perception/mir_object_segmentation/ros/include/mir_object_segmentation/scene_segmentation_ros.h
+++ b/mir_perception/mir_object_segmentation/ros/include/mir_object_segmentation/scene_segmentation_ros.h
@@ -66,11 +66,17 @@ class SceneSegmentationROS
          * \param[out] Object list with unknown labels
          * \param[out] 3D table top object clusters
          * \param[out] Bounding boxes of the clusters
+         * \param[in] Center cluster so that it has zero mean
+         * \param[in] Pad cluster so that the cluster does not have variable point size
+         * \param[in] Number of padded points
          * */
         void segmentCloud(const PointCloud::ConstPtr &cloud,
                           mas_perception_msgs::ObjectList &obj_list,
                           std::vector<PointCloud::Ptr> &clusters,
-                          std::vector<BoundingBox> &boxes);
+                          std::vector<BoundingBox> &boxes,
+                          bool center_cluster,
+                          bool pad_cluster,
+                          bool num_points);
         
         /** \brief Find plane
          * \param[in] Input point cloud

--- a/mir_perception/mir_object_segmentation/ros/src/scene_segmentation_node.cpp
+++ b/mir_perception/mir_object_segmentation/ros/src/scene_segmentation_node.cpp
@@ -86,7 +86,8 @@ void SceneSegmentationNode::segmentPointCloud()
     std::vector<PointCloud::Ptr> clusters;
     mas_perception_msgs::ObjectList object_list;
     std::vector<BoundingBox> boxes;
-    scene_segmentation_ros_.segmentCloud(cloud, object_list, clusters, boxes);
+    scene_segmentation_ros_.segmentCloud(cloud, object_list, clusters, boxes,
+                                         center_cluster_, pad_cluster_, padded_cluster_size_);
     
     mas_perception_msgs::BoundingBoxList bounding_boxes;
     bounding_boxes.bounding_boxes.resize(clusters.size());
@@ -198,6 +199,10 @@ void SceneSegmentationNode::configCallback(mir_object_segmentation::SceneSegment
     scene_segmentation_ros_.setClusterParams(config.cluster_tolerance, config.cluster_min_size, config.cluster_max_size,
             config.cluster_min_height, config.cluster_max_height, config.cluster_max_length,
             config.cluster_min_distance_to_polygon);
+
+    center_cluster_ = config.center_cluster;
+    pad_cluster_ = config.pad_cluster;
+    padded_cluster_size_ = config.padded_cluster_size;
     
     octree_resolution_ = config.octree_resolution;
     object_height_above_workspace_ = config.object_height_above_workspace;

--- a/mir_perception/mir_perception_utils/CMakeLists.txt
+++ b/mir_perception/mir_perception_utils/CMakeLists.txt
@@ -46,6 +46,7 @@ add_definitions(-fpermissive)
 ### LIBRARIES ####################################################
 add_library(${PROJECT_NAME}
   common/src/bounding_box.cpp
+  common/src/pointcloud_utils.cpp
   ros/src/object_utils_ros.cpp
   ros/src/pointcloud_utils_ros.cpp
 )

--- a/mir_perception/mir_perception_utils/common/include/mir_perception_utils/pointcloud_utils.h
+++ b/mir_perception/mir_perception_utils/common/include/mir_perception_utils/pointcloud_utils.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Bonn-Rhein-Sieg University
+ *
+ * Author: Mohammad Wasil
+ *
+ */
+
+#ifndef MIR_PERCCEPTION_UTILS_POINTCLOUD_UTILS_H
+#define MIR_PERCCEPTION_UTILS_POINTCLOUD_UTILS_H
+
+#include<mir_perception_utils/aliases.h>
+
+namespace mir_perception_utils
+{
+namespace pointcloud
+{
+     /** \brief Center PointCloud, adapted from pcl library group_common
+      * https://pointcloudlibrary.github.io/documentation/group__common.html
+      * \param[in] PointCloud input
+      * \param[out] Centered PointCloud output
+      * \return The number of valid points, if the cloud is dense, it's the same
+      * as the number of input points
+      */
+    unsigned int centerPointCloud(const PointCloud &cloud_in,
+                                  PointCloud &centered_cloud);
+    /** \brief Pad point cloud
+      * \param[in] Normalized PointCloud input
+      * \param[in] Number of points
+      * \return The number of padded points
+      */
+    unsigned int padPointCloud(PointCloud::Ptr &cloud_in,
+                              int num_points);
+
+}
+};
+
+#endif  // MIR_PERCCEPTION_UTILS_POINTCLOUD_UTILS_H

--- a/mir_perception/mir_perception_utils/common/src/pointcloud_utils.cpp
+++ b/mir_perception/mir_perception_utils/common/src/pointcloud_utils.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Bonn-Rhein-Sieg University
+ *
+ * Author: Mohammad Wasil
+ *
+ */
+#include <mir_perception_utils/pointcloud_utils.h>
+#include <pcl/common/centroid.h>
+#include <pcl/common/io.h>
+#include <pcl/PointIndices.h>
+#include <pcl/filters/extract_indices.h>
+
+using namespace mir_perception_utils;
+
+unsigned int pointcloud::centerPointCloud(const PointCloud &cloud_in,
+                             PointCloud &centered_cloud)
+{
+    if (cloud_in.empty ())
+        return (0);
+
+    pcl::copyPointCloud(cloud_in, centered_cloud);
+        
+    Eigen::Vector4f centroid;
+    pcl::compute3DCentroid(centered_cloud, centroid);
+ 
+    unsigned int point_count;
+    // Check if the data is dense, means there may be NaN or Inf values
+    if (centered_cloud.is_dense)
+    {
+        point_count = static_cast<unsigned int> (centered_cloud.points.size ());
+        // For each point in the cloud
+        for (auto& point: centered_cloud)
+        { 
+            point.x = point.x - centroid[0];
+            point.y = point.y - centroid[1];
+            point.z = point.z - centroid[2];
+        }
+    }
+    // Check NaN or Inf values, that could exist
+    else
+    {
+        point_count = 0;
+        for (auto& point: centered_cloud)
+        {
+            // Check if the point is invalid
+            if (!isFinite (point))
+                continue;
+
+            point.x = point.x - centroid[0];
+            point.y = point.y - centroid[1];
+            point.z = point.z - centroid[2];
+            ++point_count;
+        }
+    }
+    return (point_count);
+}
+
+unsigned int pointcloud::padPointCloud(PointCloud::Ptr &cloud_in,
+                                       int num_points)
+{
+    if (cloud_in->empty ())
+        return (0);
+    
+    unsigned int point_count;
+    point_count = static_cast<unsigned int> (cloud_in->size ());
+    
+    //ToDo: check if the cloud size > 2048, if so, downsample
+    if (point_count > num_points)
+    {
+        unsigned int point_diff = point_count - num_points;
+
+        std::random_device rd; // get ran
+        std::mt19937 eng(rd()); // seed the generator
+        std::uniform_int_distribution<> distr(0, point_count); 
+
+        pcl::PointIndices::Ptr random_indices(new pcl::PointIndices());
+
+        for(int n=0; n<num_points; ++n)
+            random_indices->indices.push_back(distr(eng));
+
+        pcl::ExtractIndices<PointT> extract;
+        extract.setInputCloud(cloud_in);
+        extract.setIndices(random_indices);
+        extract.setNegative(false);
+        extract.filter(*cloud_in);
+    }
+    else if (point_count < num_points)
+    {
+        int additional_points = num_points - point_count;
+        for (int i=0; i < additional_points; i++)
+        {
+            PointT p;
+            p.x = 0;
+            p.y = 0;
+            p.z = 0;
+            p.r = 0;
+            p.g = 0;
+            p.b = 0;
+            cloud_in->points.push_back(p);
+        }
+        point_count += additional_points;
+        cloud_in->width = num_points;
+    }
+    return (point_count);
+}

--- a/mir_perception/mir_perception_utils/common/src/pointcloud_utils.cpp
+++ b/mir_perception/mir_perception_utils/common/src/pointcloud_utils.cpp
@@ -64,7 +64,6 @@ unsigned int pointcloud::padPointCloud(PointCloud::Ptr &cloud_in,
     unsigned int point_count;
     point_count = static_cast<unsigned int> (cloud_in->size ());
     
-    //ToDo: check if the cloud size > 2048, if so, downsample
     if (point_count > num_points)
     {
         unsigned int point_diff = point_count - num_points;

--- a/mir_perception/mir_perception_utils/ros/include/mir_perception_utils/pointcloud_utils_ros.h
+++ b/mir_perception/mir_perception_utils/ros/include/mir_perception_utils/pointcloud_utils_ros.h
@@ -5,8 +5,8 @@
  *
  */
 
-#ifndef MIR_PERCCEPTION_UTILS_POINTCLOUD_UTILS_H
-#define MIR_PERCCEPTION_UTILS_POINTCLOUD_UTILS_H
+#ifndef MIR_PERCCEPTION_UTILS_POINTCLOUD_UTILS_ROS_H
+#define MIR_PERCCEPTION_UTILS_POINTCLOUD_UTILS_ROS_H
 
 #include <ros/ros.h>
 
@@ -63,11 +63,11 @@ namespace pointcloud
      * \param[in] Remove 3D ROI outliers
     */
     void getPointCloudROI(const sensor_msgs::RegionOfInterest &roi, 
-                          const PointCloud::Ptr &cloud_id,
+                          const PointCloud::Ptr &cloud_in,
                           PointCloud::Ptr &cloud_roi,
                           float roi_size_adjustment,
                           bool remove_outliers);
 }
 };
 
-#endif  // MIR_PERCCEPTION_UTILS_POINTCLOUD_UTILS_H
+#endif  // MIR_PERCCEPTION_UTILS_POINTCLOUD_UTILS_ROS_H


### PR DESCRIPTION
* Add pointcloud_utils
  * Center pointcloud so that it has zero mean. This is done after segmenting the table top clusters in the cpp code, rather than in pcl_object_recognizer node. Thus it should save the computation time
  * Add option to pad point cloud too. This is done to avoid doing the same thing in the pc object recognition node, and is requires to pad point clouds for cnn based classifiers
* ToDo:
  * 