### PR TITLE
Using GenericExecuteAction instead of old MoveBaseSafeAction

### DIFF
--- a/mir_planning/mir_refbox_parser/CMakeLists.txt
+++ b/mir_planning/mir_refbox_parser/CMakeLists.txt
@@ -15,6 +15,7 @@ catkin_package(
     std_msgs
     sensor_msgs
     geometry_msgs
+    mir_planning_msgs
     tf
 )
 

--- a/mir_planning/mir_refbox_parser/package.xml
+++ b/mir_planning/mir_refbox_parser/package.xml
@@ -21,5 +21,6 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>mir_planning_msgs</run_depend>
   <run_depend>tf</run_depend>
 </package>


### PR DESCRIPTION
<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

- Using GenericExecuteAction instead of Outdated MoveBaseSafeAction in `mir_refbox_parser`

## Related PRs
<!-- Mention any other pull requests that need to be merged (and in which order, if applicable). -->
<!--If your PR is related to an issue, you can close the issue by using keywords: https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- For example, just write: Closes #31 -->

Closes #140

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
