### PR TITLE
Update planning domain with actions for picking object from drawer

### DIFF
--- a/mir_planning/mir_knowledge/common/pddl/general_domain/domain.pddl
+++ b/mir_planning/mir_knowledge/common/pddl/general_domain/domain.pddl
@@ -5,6 +5,7 @@
   	robot         		; your amazing yet powerful robot
   	object				    ; objects to be manipulated by the robot
   	robot_platform		; platform slots for the robot to store objects
+	drawer              ; drawer to store objects
  )
 
  (:predicates
@@ -43,6 +44,20 @@
 	; gets lost if the robot moves the base
 	(perceived ?l - location)
 
+	; specifies whether the gripper has opened the drawer ?d
+	(opened ?d - drawer)
+
+ 	; drawer location ?d is occupied, yb has 3 free places to store objects
+	(occupied ?d - drawer)
+
+	; object ?o is located inside drawer ?d
+	(inside ?o - object ?d - drawer)
+
+	; contents of drawer ?d are perceived
+	(perceived_inside ?d - drawer)
+
+	; draw ?d is located at location ?l
+	(located_at ?d - drawer ?l - location)
  )
 
  (:functions
@@ -56,7 +71,7 @@
  (:action move_base
     :parameters (?r - robot ?source ?destination - location)
     :precondition (and (at ?r ?source)
-     					    (gripper_is_free ?r)
+     				   (gripper_is_free ?r)
      			  )
     :effect (and (not (at ?r ?source))
      			        (at ?r ?destination)
@@ -169,4 +184,91 @@
    					(increase (total-cost) 5)
    			)
  )
-)
+
+ ; open a drawer ?d using the robot gripper
+ ; with robot ?r that is at location ?draw_loc
+ (:action open
+     :parameters (?r - robot ?draw_loc - location ?d - drawer)
+     :precondition 	(and 	(at ?r ?draw_loc)
+	 						(located_at ?d ?draw_loc)
+                      		(gripper_is_free ?r)
+							(not (opened ?d))
+                   	)
+     :effect (and  	(opened ?d)
+                   	(gripper_is_free ?r)
+                   	(increase (total-cost) 2)
+             )
+ )
+
+ ; close a drawer ?d using the robot gripper
+ ; with robot ?r that is at location ?draw_loc
+ (:action close
+     :parameters (?r - robot ?draw_loc - location ?d - drawer)
+     :precondition 	(and 	(at ?r ?draw_loc)
+	 						(located_at ?d ?draw_loc)
+                      		(gripper_is_free ?r)
+							(opened ?d)
+                   	)
+     :effect (and  	(not (opened ?d))
+                   	(gripper_is_free ?r)
+                   	(increase (total-cost) 2)
+             )
+ )
+
+; perceive a an object ?o in a drawer ?d with an empty robot gripper
+ ; to find the pose of this object before it can be picked
+ (:action perceive_inside_drawer
+   :parameters (?r - robot ?draw_loc - location ?d - drawer)
+   :precondition 	(and 	(at ?r ?draw_loc)
+							(located_at ?d ?draw_loc)
+							(opened ?d)
+   							(gripper_is_free ?r)
+   							(not (perceived_inside ?d))
+   					)
+   :effect 	(and 	(perceived_inside ?d)
+                    (increase (total-cost) 10)
+  			)
+ )
+
+ ; pick an object ?o which is inside a drawer ?d at location ?draw_loc with a free gripper
+ ; with robot ?r that is at location ?draw_loc
+ (:action pick_from_drawer
+     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
+     :precondition 	(and 	(inside ?o ?d)
+                      		(at ?r ?draw_loc)
+							(located_at ?d ?draw_loc)
+                      		(perceived_inside ?d)
+                      		(gripper_is_free ?r)
+                      		(not (holding ?r ?o))
+                      		(not (heavy ?o))
+							(opened ?d)
+                   	)
+     :effect (and  	(holding ?r ?o)
+                   	(not (inside ?o ?d))
+                   	(not (gripper_is_free ?r))
+					(not (occupied ?d))
+                   	(increase (total-cost) 2)
+             )
+ )
+
+ ; place an object ?o inside a drawer ?d at location ?drawer
+ ; with robot ?r that is at location ?draw_loc
+ (:action place_inside_drawer
+     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
+     :precondition  (and  (at ?r ?draw_loc)
+	 					  (located_at ?d ?draw_loc)
+                          (holding ?r ?o)
+                          (not (inside ?o ?d))
+                          (not (insertable ?o ))
+                          (not (gripper_is_free ?r))
+						  (opened ?d)
+						  (not (occupied ?d))
+                    )
+     :effect (and   (inside ?o ?d)
+                    (not (holding ?r ?o))
+                    (gripper_is_free ?r)
+					(occupied ?d)
+                    (increase (total-cost) 2)
+             )
+ )
+ )

--- a/mir_planning/mir_knowledge/common/pddl/general_domain/domain.pddl
+++ b/mir_planning/mir_knowledge/common/pddl/general_domain/domain.pddl
@@ -6,7 +6,6 @@
   	object				; objects to be manipulated by the robot
   	robot_platform		; platform slots for the robot to store objects
 	drawer              ; drawer to store objects
-	drawer_slots        ; slots in drawer to store objects
  )
 
  (:predicates
@@ -47,9 +46,6 @@
 
 	; specifies whether the gripper has opened the drawer ?d
 	(opened ?d - drawer)
-
- 	; drawer location ?d is occupied, yb has 3 free places to store objects
-	(occupied ?slots - drawer_slots)
 
 	; object ?o is located inside drawer ?d
 	(inside ?o - object ?d - drawer)
@@ -192,6 +188,7 @@
      :parameters (?r - robot ?draw_loc - location ?d - drawer)
      :precondition 	(and 	(at ?r ?draw_loc)
 	 						(located_at ?d ?draw_loc)
+							(perceived ?draw_loc)
                       		(gripper_is_free ?r)
 							(not (opened ?d))
                    	)
@@ -234,7 +231,7 @@
  ; pick an object ?o which is inside a drawer ?d at location ?draw_loc with a free gripper
  ; with robot ?r that is at location ?draw_loc
  (:action pick_from_drawer
-     :parameters (?r - robot ?draw_loc - location ?d - drawer  ?slots - drawer_slots ?o - object)
+     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
      :precondition 	(and 	(inside ?o ?d)
                       		(at ?r ?draw_loc)
 							(located_at ?d ?draw_loc)
@@ -242,13 +239,11 @@
                       		(gripper_is_free ?r)
                       		(not (holding ?r ?o))
                       		(not (heavy ?o))
-							(occupied ?slots)
 							(opened ?d)
                    	)
      :effect (and  	(holding ?r ?o)
                    	(not (inside ?o ?d))
                    	(not (gripper_is_free ?r))
-					(not (occupied ?slots))
                    	(increase (total-cost) 2)
              )
  )
@@ -256,20 +251,17 @@
  ; place an object ?o inside a drawer ?d at location ?drawer
  ; with robot ?r that is at location ?draw_loc
  (:action place_inside_drawer
-     :parameters (?r - robot ?draw_loc - location ?d - drawer  ?slots - drawer_slots ?o - object)
+     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
      :precondition  (and  (at ?r ?draw_loc)
 	 					  (located_at ?d ?draw_loc)
                           (holding ?r ?o)
-                          (not (inside ?o ?d))
                           (not (insertable ?o ))
                           (not (gripper_is_free ?r))
 						  (opened ?d)
-						  (not (occupied ?slots))
                     )
      :effect (and   (inside ?o ?d)
                     (not (holding ?r ?o))
                     (gripper_is_free ?r)
-					(occupied ?slots)
                     (increase (total-cost) 2)
              )
  )

--- a/mir_planning/mir_knowledge/common/pddl/general_domain/domain.pddl
+++ b/mir_planning/mir_knowledge/common/pddl/general_domain/domain.pddl
@@ -3,9 +3,10 @@
  (:types
   	location      		; service areas, points of interest, navigation goals
   	robot         		; your amazing yet powerful robot
-  	object				    ; objects to be manipulated by the robot
+  	object				; objects to be manipulated by the robot
   	robot_platform		; platform slots for the robot to store objects
 	drawer              ; drawer to store objects
+	drawer_slots        ; slots in drawer to store objects
  )
 
  (:predicates
@@ -48,7 +49,7 @@
 	(opened ?d - drawer)
 
  	; drawer location ?d is occupied, yb has 3 free places to store objects
-	(occupied ?d - drawer)
+	(occupied ?slots - drawer_slots)
 
 	; object ?o is located inside drawer ?d
 	(inside ?o - object ?d - drawer)
@@ -233,7 +234,7 @@
  ; pick an object ?o which is inside a drawer ?d at location ?draw_loc with a free gripper
  ; with robot ?r that is at location ?draw_loc
  (:action pick_from_drawer
-     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
+     :parameters (?r - robot ?draw_loc - location ?d - drawer  ?slots - drawer_slots ?o - object)
      :precondition 	(and 	(inside ?o ?d)
                       		(at ?r ?draw_loc)
 							(located_at ?d ?draw_loc)
@@ -241,12 +242,13 @@
                       		(gripper_is_free ?r)
                       		(not (holding ?r ?o))
                       		(not (heavy ?o))
+							(occupied ?slots)
 							(opened ?d)
                    	)
      :effect (and  	(holding ?r ?o)
                    	(not (inside ?o ?d))
                    	(not (gripper_is_free ?r))
-					(not (occupied ?d))
+					(not (occupied ?slots))
                    	(increase (total-cost) 2)
              )
  )
@@ -254,7 +256,7 @@
  ; place an object ?o inside a drawer ?d at location ?drawer
  ; with robot ?r that is at location ?draw_loc
  (:action place_inside_drawer
-     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
+     :parameters (?r - robot ?draw_loc - location ?d - drawer  ?slots - drawer_slots ?o - object)
      :precondition  (and  (at ?r ?draw_loc)
 	 					  (located_at ?d ?draw_loc)
                           (holding ?r ?o)
@@ -262,12 +264,12 @@
                           (not (insertable ?o ))
                           (not (gripper_is_free ?r))
 						  (opened ?d)
-						  (not (occupied ?d))
+						  (not (occupied ?slots))
                     )
      :effect (and   (inside ?o ?d)
                     (not (holding ?r ?o))
                     (gripper_is_free ?r)
-					(occupied ?d)
+					(occupied ?slots)
                     (increase (total-cost) 2)
              )
  )

--- a/mir_planning/mir_task_planning/common/pddl/domain.pddl
+++ b/mir_planning/mir_task_planning/common/pddl/domain.pddl
@@ -188,6 +188,7 @@
      :parameters (?r - robot ?draw_loc - location ?d - drawer)
      :precondition 	(and 	(at ?r ?draw_loc)
 	 						(located_at ?d ?draw_loc)
+							(perceived ?draw_loc)
                       		(gripper_is_free ?r)
 							(not (opened ?d))
                    	)

--- a/mir_planning/mir_task_planning/common/pddl/domain.pddl
+++ b/mir_planning/mir_task_planning/common/pddl/domain.pddl
@@ -5,6 +5,7 @@
   	robot         		; your amazing yet powerful robot
   	object				    ; objects to be manipulated by the robot
   	robot_platform		; platform slots for the robot to store objects
+	drawer              ; drawer to store objects
  )
 
  (:predicates
@@ -43,6 +44,20 @@
 	; gets lost if the robot moves the base
 	(perceived ?l - location)
 
+	; specifies whether the gripper has opened the drawer ?d
+	(opened ?d - drawer)
+
+ 	; drawer location ?d is occupied, yb has 3 free places to store objects
+	(occupied ?d - drawer)
+
+	; object ?o is located inside drawer ?d
+	(inside ?o - object ?d - drawer)
+
+	; contents of drawer ?d are perceived
+	(perceived_inside ?d - drawer)
+
+	; draw ?d is located at location ?l
+	(located_at ?d - drawer ?l - location)
  )
 
  (:functions
@@ -56,7 +71,7 @@
  (:action move_base
     :parameters (?r - robot ?source ?destination - location)
     :precondition (and (at ?r ?source)
-     					    (gripper_is_free ?r)
+     				   (gripper_is_free ?r)
      			  )
     :effect (and (not (at ?r ?source))
      			        (at ?r ?destination)
@@ -169,4 +184,91 @@
    					(increase (total-cost) 5)
    			)
  )
-)
+
+ ; open a drawer ?d using the robot gripper
+ ; with robot ?r that is at location ?draw_loc
+ (:action open
+     :parameters (?r - robot ?draw_loc - location ?d - drawer)
+     :precondition 	(and 	(at ?r ?draw_loc)
+	 						(located_at ?d ?draw_loc)
+                      		(gripper_is_free ?r)
+							(not (opened ?d))
+                   	)
+     :effect (and  	(opened ?d)
+                   	(gripper_is_free ?r)
+                   	(increase (total-cost) 2)
+             )
+ )
+
+ ; close a drawer ?d using the robot gripper
+ ; with robot ?r that is at location ?draw_loc
+ (:action close
+     :parameters (?r - robot ?draw_loc - location ?d - drawer)
+     :precondition 	(and 	(at ?r ?draw_loc)
+	 						(located_at ?d ?draw_loc)
+                      		(gripper_is_free ?r)
+							(opened ?d)
+                   	)
+     :effect (and  	(not (opened ?d))
+                   	(gripper_is_free ?r)
+                   	(increase (total-cost) 2)
+             )
+ )
+
+; perceive a an object ?o in a drawer ?d with an empty robot gripper
+ ; to find the pose of this object before it can be picked
+ (:action perceive_inside_drawer
+   :parameters (?r - robot ?draw_loc - location ?d - drawer)
+   :precondition 	(and 	(at ?r ?draw_loc)
+							(located_at ?d ?draw_loc)
+							(opened ?d)
+   							(gripper_is_free ?r)
+   							(not (perceived_inside ?d))
+   					)
+   :effect 	(and 	(perceived_inside ?d)
+                    (increase (total-cost) 10)
+  			)
+ )
+
+ ; pick an object ?o which is inside a drawer ?d at location ?draw_loc with a free gripper
+ ; with robot ?r that is at location ?draw_loc
+ (:action pick_from_drawer
+     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
+     :precondition 	(and 	(inside ?o ?d)
+                      		(at ?r ?draw_loc)
+							(located_at ?d ?draw_loc)
+                      		(perceived_inside ?d)
+                      		(gripper_is_free ?r)
+                      		(not (holding ?r ?o))
+                      		(not (heavy ?o))
+							(opened ?d)
+                   	)
+     :effect (and  	(holding ?r ?o)
+                   	(not (inside ?o ?d))
+                   	(not (gripper_is_free ?r))
+					(not (occupied ?d))
+                   	(increase (total-cost) 2)
+             )
+ )
+
+ ; place an object ?o inside a drawer ?d at location ?drawer
+ ; with robot ?r that is at location ?draw_loc
+ (:action place_inside_drawer
+     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
+     :precondition  (and  (at ?r ?draw_loc)
+	 					  (located_at ?d ?draw_loc)
+                          (holding ?r ?o)
+                          (not (inside ?o ?d))
+                          (not (insertable ?o ))
+                          (not (gripper_is_free ?r))
+						  (opened ?d)
+						  (not (occupied ?d))
+                    )
+     :effect (and   (inside ?o ?d)
+                    (not (holding ?r ?o))
+                    (gripper_is_free ?r)
+					(occupied ?d)
+                    (increase (total-cost) 2)
+             )
+ )
+ )

--- a/mir_planning/mir_task_planning/common/pddl/domain.pddl
+++ b/mir_planning/mir_task_planning/common/pddl/domain.pddl
@@ -3,9 +3,10 @@
  (:types
   	location      		; service areas, points of interest, navigation goals
   	robot         		; your amazing yet powerful robot
-  	object				    ; objects to be manipulated by the robot
+  	object				; objects to be manipulated by the robot
   	robot_platform		; platform slots for the robot to store objects
 	drawer              ; drawer to store objects
+	drawer_slots        ; slots in drawer to store objects
  )
 
  (:predicates
@@ -48,7 +49,7 @@
 	(opened ?d - drawer)
 
  	; drawer location ?d is occupied, yb has 3 free places to store objects
-	(occupied ?d - drawer)
+	(occupied ?slots - drawer_slots)
 
 	; object ?o is located inside drawer ?d
 	(inside ?o - object ?d - drawer)
@@ -233,7 +234,7 @@
  ; pick an object ?o which is inside a drawer ?d at location ?draw_loc with a free gripper
  ; with robot ?r that is at location ?draw_loc
  (:action pick_from_drawer
-     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
+     :parameters (?r - robot ?draw_loc - location ?d - drawer  ?slots - drawer_slots ?o - object)
      :precondition 	(and 	(inside ?o ?d)
                       		(at ?r ?draw_loc)
 							(located_at ?d ?draw_loc)
@@ -241,12 +242,13 @@
                       		(gripper_is_free ?r)
                       		(not (holding ?r ?o))
                       		(not (heavy ?o))
+							(occupied ?slots)
 							(opened ?d)
                    	)
      :effect (and  	(holding ?r ?o)
                    	(not (inside ?o ?d))
                    	(not (gripper_is_free ?r))
-					(not (occupied ?d))
+					(not (occupied ?slots))
                    	(increase (total-cost) 2)
              )
  )
@@ -254,7 +256,7 @@
  ; place an object ?o inside a drawer ?d at location ?drawer
  ; with robot ?r that is at location ?draw_loc
  (:action place_inside_drawer
-     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
+     :parameters (?r - robot ?draw_loc - location ?d - drawer  ?slots - drawer_slots ?o - object)
      :precondition  (and  (at ?r ?draw_loc)
 	 					  (located_at ?d ?draw_loc)
                           (holding ?r ?o)
@@ -262,12 +264,12 @@
                           (not (insertable ?o ))
                           (not (gripper_is_free ?r))
 						  (opened ?d)
-						  (not (occupied ?d))
+						  (not (occupied ?slots))
                     )
      :effect (and   (inside ?o ?d)
                     (not (holding ?r ?o))
                     (gripper_is_free ?r)
-					(occupied ?d)
+					(occupied ?slots)
                     (increase (total-cost) 2)
              )
  )

--- a/mir_planning/mir_task_planning/common/pddl/domain.pddl
+++ b/mir_planning/mir_task_planning/common/pddl/domain.pddl
@@ -255,6 +255,7 @@
      :precondition  (and  (at ?r ?draw_loc)
 	 					  (located_at ?d ?draw_loc)
                           (holding ?r ?o)
+						  (perceived ?draw_loc)
                           (not (insertable ?o ))
                           (not (gripper_is_free ?r))
 						  (opened ?d)

--- a/mir_planning/mir_task_planning/common/pddl/domain.pddl
+++ b/mir_planning/mir_task_planning/common/pddl/domain.pddl
@@ -6,7 +6,6 @@
   	object				; objects to be manipulated by the robot
   	robot_platform		; platform slots for the robot to store objects
 	drawer              ; drawer to store objects
-	drawer_slots        ; slots in drawer to store objects
  )
 
  (:predicates
@@ -47,9 +46,6 @@
 
 	; specifies whether the gripper has opened the drawer ?d
 	(opened ?d - drawer)
-
- 	; drawer location ?d is occupied, yb has 3 free places to store objects
-	(occupied ?slots - drawer_slots)
 
 	; object ?o is located inside drawer ?d
 	(inside ?o - object ?d - drawer)
@@ -234,7 +230,7 @@
  ; pick an object ?o which is inside a drawer ?d at location ?draw_loc with a free gripper
  ; with robot ?r that is at location ?draw_loc
  (:action pick_from_drawer
-     :parameters (?r - robot ?draw_loc - location ?d - drawer  ?slots - drawer_slots ?o - object)
+     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
      :precondition 	(and 	(inside ?o ?d)
                       		(at ?r ?draw_loc)
 							(located_at ?d ?draw_loc)
@@ -242,13 +238,11 @@
                       		(gripper_is_free ?r)
                       		(not (holding ?r ?o))
                       		(not (heavy ?o))
-							(occupied ?slots)
 							(opened ?d)
                    	)
      :effect (and  	(holding ?r ?o)
                    	(not (inside ?o ?d))
                    	(not (gripper_is_free ?r))
-					(not (occupied ?slots))
                    	(increase (total-cost) 2)
              )
  )
@@ -256,20 +250,17 @@
  ; place an object ?o inside a drawer ?d at location ?drawer
  ; with robot ?r that is at location ?draw_loc
  (:action place_inside_drawer
-     :parameters (?r - robot ?draw_loc - location ?d - drawer  ?slots - drawer_slots ?o - object)
+     :parameters (?r - robot ?draw_loc - location ?d - drawer ?o - object)
      :precondition  (and  (at ?r ?draw_loc)
 	 					  (located_at ?d ?draw_loc)
                           (holding ?r ?o)
-                          (not (inside ?o ?d))
                           (not (insertable ?o ))
                           (not (gripper_is_free ?r))
 						  (opened ?d)
-						  (not (occupied ?slots))
                     )
      :effect (and   (inside ?o ?d)
                     (not (holding ?r ?o))
                     (gripper_is_free ?r)
-					(occupied ?slots)
                     (increase (total-cost) 2)
              )
  )

--- a/mir_planning/mir_task_planning/common/pddl/drawer_problem.pddl
+++ b/mir_planning/mir_task_planning/common/pddl/drawer_problem.pddl
@@ -1,0 +1,38 @@
+;This PDDL problem definition was made automatically from a KB snapshot
+(define (problem general_domain_task)
+(:domain general_domain)
+
+(:objects
+    DRAWLOC01 SH01 CB01 WS01 WS02 START END - location
+    R20 M20 M30-00 M30-01 AXIS BEARING - object
+    YOUBOT-BRSU - robot
+    PLATFORM_MIDDLE PLATFORM_LEFT PLATFORM_RIGHT - robot_platform
+    DRAW01 - drawer
+)
+
+(:init
+    ;Cost information starts
+    (= (total-cost) 0)
+    ;Cost information ends
+
+    (at YOUBOT-BRSU START)
+    (gripper_is_free YOUBOT-BRSU)
+    (located_at DRAW01 DRAWLOC01)
+    (inside R20 DRAW01)
+    (on M20 WS01)
+    (on AXIS WS02)
+    (on BEARING WS01)
+)
+
+(:goal (and
+    (on R20 WS01)
+    (inside M20 DRAW01)
+    (inside AXIS DRAW01)
+    (not (opened DRAW01))
+    )
+)
+
+(:metric minimize (total-cost))
+
+)
+

--- a/mir_planning/mir_task_planning/common/pddl/drawer_problem.pddl
+++ b/mir_planning/mir_task_planning/common/pddl/drawer_problem.pddl
@@ -8,7 +8,6 @@
     YOUBOT-BRSU - robot
     PLATFORM_MIDDLE PLATFORM_LEFT PLATFORM_RIGHT - robot_platform
     DRAW01 - drawer
-    DRAW01_MIDDLE, DRAW01_LEFT, DRAW01_RIGHT - drawer_slots
 )
 
 (:init
@@ -20,7 +19,6 @@
     (gripper_is_free YOUBOT-BRSU)
     (located_at DRAW01 DRAW01_LOC)
     (inside R20 DRAW01)
-    (occupied DRAW01_RIGHT)
     (on M20 WS01)
     (on AXIS WS02)
     (on BEARING SH01)

--- a/mir_planning/mir_task_planning/common/pddl/drawer_problem.pddl
+++ b/mir_planning/mir_task_planning/common/pddl/drawer_problem.pddl
@@ -3,11 +3,12 @@
 (:domain general_domain)
 
 (:objects
-    DRAWLOC01 SH01 CB01 WS01 WS02 START END - location
+    DRAW01_LOC SH01 CB01 WS01 WS02 START END - location
     R20 M20 M30-00 M30-01 AXIS BEARING - object
     YOUBOT-BRSU - robot
     PLATFORM_MIDDLE PLATFORM_LEFT PLATFORM_RIGHT - robot_platform
     DRAW01 - drawer
+    DRAW01_MIDDLE, DRAW01_LEFT, DRAW01_RIGHT - drawer_slots
 )
 
 (:init
@@ -17,17 +18,19 @@
 
     (at YOUBOT-BRSU START)
     (gripper_is_free YOUBOT-BRSU)
-    (located_at DRAW01 DRAWLOC01)
+    (located_at DRAW01 DRAW01_LOC)
     (inside R20 DRAW01)
+    (occupied DRAW01_RIGHT)
     (on M20 WS01)
     (on AXIS WS02)
-    (on BEARING WS01)
+    (on BEARING SH01)
 )
 
 (:goal (and
     (on R20 WS01)
     (inside M20 DRAW01)
     (inside AXIS DRAW01)
+    (inside BEARING DRAW01)
     (not (opened DRAW01))
     )
 )


### PR DESCRIPTION
Additional actions are added to domain.pddl to plan for picking an object from a drawer.

## Changelog
* Updated domain.pddl with open, close, perceive draw actions

Closes #117 


## Checklist:
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.
