### PR TITLE
Bugfix : Revert back to original problem file

### DIFF
--- a/mir_planning/mir_task_planning/common/planner_wrapper/planner_wrapper.py
+++ b/mir_planning/mir_task_planning/common/planner_wrapper/planner_wrapper.py
@@ -276,7 +276,7 @@ def get_domain_and_problem_file():
     code_dir = os.path.abspath(os.path.dirname(__file__))
     common_dir = os.path.dirname(code_dir)
     domain_file = os.path.join(common_dir, "pddl/domain.pddl")
-    problem_file = os.path.join(common_dir, "pddl/drawer_problem.pddl")
+    problem_file = os.path.join(common_dir, "pddl/problem.pddl")
     files = {"domain": None, "problem": None}
     try:
         with open(domain_file, "r") as file_handle:


### PR DESCRIPTION
The original problem file has been replaced by the drawer problem file due to #144 . This has to be changed to the original problem, since the drawer problem file is just used for testing the newly added drawer features in domain.pddl.

## Changelog
* Updated planner_wrapper.py with original problem file

## Related PRs
#144 

Related to #117 

## Checklist:
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.
