### PR TITLE
Fix melodic perception

### DIFF
--- a/mir_perception/mir_object_recognition/CMakeLists.txt
+++ b/mir_perception/mir_object_recognition/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mir_object_recognition)
 
-## Compile as C++11, supported in ROS Kinetic and newer
+# Compile as C++11 for ROS Kinetic and newer
+# use -O3 for performance mode
+# use -g for debug
 add_compile_options(-std=c++11
   -O3
-  -march=native
 )
 
 find_package(catkin REQUIRED COMPONENTS

--- a/mir_perception/mir_object_recognition/ros/launch/pc_object_recognition.launch
+++ b/mir_perception/mir_object_recognition/ros/launch/pc_object_recognition.launch
@@ -3,8 +3,8 @@
 
   <arg name="input_pointcloud_topic" default="/arm_cam3d/depth_registered/points" />
   <arg name="target_frame" default="odom" />
-  <arg name="model" default="feature_based" />
-  <arg name="model_id" default="fvrdd" />
+  <arg name="model" default="cnn_based" />
+  <arg name="model_id" default="dgcnn" />
   <arg name="dataset" default="asus" />
 
   <group ns="mir_perception">

--- a/mir_perception/mir_object_segmentation/CMakeLists.txt
+++ b/mir_perception/mir_object_segmentation/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 2.8.3)
 project(mir_object_segmentation)
 
 # Compile as C++11 for ROS Kinetic and newer
+# use -O3 for performance mode
+# use -g for debug
 add_compile_options(-std=c++11
   -O3
-  -march=native
 )
 
 find_package(catkin REQUIRED

--- a/mir_perception/mir_object_segmentation/common/src/scene_segmentation.cpp
+++ b/mir_perception/mir_object_segmentation/common/src/scene_segmentation.cpp
@@ -111,9 +111,7 @@ PointCloud::Ptr SceneSegmentation::findPlane(const PointCloud::ConstPtr &cloud,
   convex_hull_.setInputCloud(plane);
   convex_hull_.reconstruct(*hull);
 
-  // not sure if this is necessary
-  hull->points.push_back(hull->points.front());
-  hull->width += 1;
+  // determine workspace height based on the mean of z axis 
   double z = 0.0;
   for (int i = 0; i < hull->points.size(); i++) {
     z += hull->points[i].z;

--- a/mir_perception/mir_perception_utils/CMakeLists.txt
+++ b/mir_perception/mir_perception_utils/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 2.8.3)
 project(mir_perception_utils)
 
 # Compile as C++11 for ROS Kinetic and newer
+# use -O3 for performance mode
+# use -g for debug
 add_compile_options(-std=c++11
   -O3
-  -march=native
 )
 
 find_package(catkin REQUIRED


### PR DESCRIPTION
* Set Dynamic Graph CNN as default cloud recognizer
* Remove `march=native` in compiler:
  * Using `march=native` breaks some pcl libraries as it tries to compile binary packages on top of pcl libraries for the build machine instead of using standard Ubuntu std arch flags. It may not work in some cpu arcs
  * Related: [here](https://github.com/PointCloudLibrary/pcl/issues/641)