### PR TITLE
Use joint vel controller for individual arm joints

### DIFF
--- a/mir_robots/mir_hardware_config/youbot-brsu-4/urdf/robot.urdf.xacro
+++ b/mir_robots/mir_hardware_config/youbot-brsu-4/urdf/robot.urdf.xacro
@@ -77,17 +77,6 @@
    </joint>
    <!-- we create a fixed link from arm_cam3d_camera_link to
         arm_cam3d_camera_color_optical_frame. See issue -->
-   <link name="fixed_camera_link">
-       <visual>
-           <geometry>
-               <box size="0.0000001 0.000001 0.000001"/>
-           </geometry>
-       </visual>
-       <collision>
-           <geometry>
-               <box size="0.0000001 0.000001 0.000001"/>
-           </geometry>
-       </collision>
-   </link>
+   <link name="fixed_camera_link"/>
 
 </robot>

--- a/mir_simulation/mir_bringup_sim/robot.launch
+++ b/mir_simulation/mir_bringup_sim/robot.launch
@@ -12,6 +12,8 @@
   <arg name="init_pos_y" default="0.0"/>
   <arg name="init_pos_z" default="0.08"/>
 
+  <arg name="use_arm_traj_ctrl" default="true"/>
+
   <!-- upload robot params (joint configurations) -->
   <include file="$(find mir_default_robot_config)/upload_param.launch" >
     <arg name="robot" value="$(arg robot)" />
@@ -44,6 +46,8 @@
   </node>
 
   <!-- load robot specific launch files -->
-  <include file="$(find mir_bringup_sim)/robots/$(arg robot).launch" />
+  <include file="$(find mir_bringup_sim)/robots/$(arg robot).launch">
+    <arg name="use_arm_traj_ctrl" value="$(arg use_arm_traj_ctrl)" />
+  </include>
 
 </launch>

--- a/mir_simulation/mir_bringup_sim/robots/youbot-brsu-1.launch
+++ b/mir_simulation/mir_bringup_sim/robots/youbot-brsu-1.launch
@@ -1,11 +1,18 @@
 <?xml version="1.0"?>
 <launch>
 
+  <arg name="use_arm_traj_ctrl" default="true"/>
+
   <!-- launch base controller -->
   <include file="$(find youbot_gazebo_control)/launch/base_controller.launch" />
 
   <!-- launch arm and gripper controller -->
-  <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  <group if="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  </group>
+  <group unless="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/vel_arm_controller.launch" />
+  </group>
 
   <include file="$(find youbot_gazebo_control)/launch/gripper_controller.launch" />
   <include file="$(find mir_arm_cartesian_control)/ros/launch/arm_cartesian_control_youbot.launch" />

--- a/mir_simulation/mir_bringup_sim/robots/youbot-brsu-2.launch
+++ b/mir_simulation/mir_bringup_sim/robots/youbot-brsu-2.launch
@@ -1,11 +1,18 @@
 <?xml version="1.0"?>
 <launch>
 
+  <arg name="use_arm_traj_ctrl" default="true"/>
+
   <!-- launch base controller -->
   <include file="$(find youbot_gazebo_control)/launch/base_controller.launch" />
 
   <!-- launch arm and gripper controller -->
-  <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  <group if="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  </group>
+  <group unless="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/vel_arm_controller.launch" />
+  </group>
 
   <include file="$(find mir_arm_cartesian_control)/ros/launch/arm_cartesian_control_youbot.launch" />
 

--- a/mir_simulation/mir_bringup_sim/robots/youbot-brsu-3.launch
+++ b/mir_simulation/mir_bringup_sim/robots/youbot-brsu-3.launch
@@ -1,11 +1,18 @@
 <?xml version="1.0"?>
 <launch>
 
+  <arg name="use_arm_traj_ctrl" default="true"/>
+
   <!-- launch base controller -->
   <include file="$(find youbot_gazebo_control)/launch/base_controller.launch" />
 
   <!-- launch arm and gripper controller -->
-  <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  <group if="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  </group>
+  <group unless="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/vel_arm_controller.launch" />
+  </group>
 
   <include file="$(find mir_arm_cartesian_control)/ros/launch/arm_cartesian_control_youbot.launch" />
 

--- a/mir_simulation/mir_bringup_sim/robots/youbot-brsu-4.launch
+++ b/mir_simulation/mir_bringup_sim/robots/youbot-brsu-4.launch
@@ -1,11 +1,18 @@
 <?xml version="1.0"?>
 <launch>
 
+  <arg name="use_arm_traj_ctrl" default="true"/>
+
   <!-- launch base controller -->
   <include file="$(find youbot_gazebo_control)/launch/base_controller.launch" />
 
   <!-- launch arm and gripper controller -->
-  <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  <group if="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  </group>
+  <group unless="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/vel_arm_controller.launch" />
+  </group>
 
   <include file="$(find mir_arm_cartesian_control)/ros/launch/arm_cartesian_control_youbot.launch" />
 

--- a/mir_simulation/mir_bringup_sim/robots/youbot-brsu-5.launch
+++ b/mir_simulation/mir_bringup_sim/robots/youbot-brsu-5.launch
@@ -1,11 +1,18 @@
 <?xml version="1.0"?>
 <launch>
 
+  <arg name="use_arm_traj_ctrl" default="true"/>
+
   <!-- launch base controller -->
   <include file="$(find youbot_gazebo_control)/launch/base_controller.launch" />
 
   <!-- launch arm controller -->
-  <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  <group if="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  </group>
+  <group unless="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/vel_arm_controller.launch" />
+  </group>
 
   <!-- launch dynamixel gripper controller -->
   <rosparam file="$(find mir_bringup_sim)/controller/dynamixel_gripper_controller.yaml" command="load" ns="arm_1"/> <!-- upload gripper controller parameters -->

--- a/mir_simulation/mir_bringup_sim/robots/youbot-brsu-arm.launch
+++ b/mir_simulation/mir_bringup_sim/robots/youbot-brsu-arm.launch
@@ -1,8 +1,15 @@
 <?xml version="1.0"?>
 <launch>
 
+  <arg name="use_arm_traj_ctrl" default="true"/>
+
   <!-- launch arm and gripper controller -->
-  <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  <group if="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  </group>
+  <group unless="$(arg use_arm_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/vel_arm_controller.launch" />
+  </group>
 
   <include file="$(find youbot_gazebo_control)/launch/gripper_controller.launch" />
   <!-- <include file="$(find mir_arm_cartesian_control)/ros/launch/arm_cartesian_control_youbot.launch" /> -->


### PR DESCRIPTION
<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->
Based on `use_arm_traj_ctrl` argument in launch file for robots in `mir_bringup_sim`, either trajectory controller or joint velocity controller will be used. Trajectory controller provides the interface used by moveit whereas joint velocity controller provides the interface used by `arm_cartesian_controller`

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->
- Added if unless group to launch different controller in `mir_bringup_sim` launch files

## Related PRs
<!-- Mention any other pull requests that need to be merged (and in which order, if applicable). -->
<!--If your PR is related to an issue, you can close the issue by using keywords: https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- For example, just write: Closes #31 -->

Related to https://github.com/mas-group/youbot_simulation/pull/18

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
