### PR TITLE
[mir_object_rec] improve handling of errors related to transforming PC

### DIFF
--- a/images/mas_industrial_robotics/Dockerfile
+++ b/images/mas_industrial_robotics/Dockerfile
@@ -4,11 +4,8 @@ FROM osrf/ros:$ROS_DISTRO-desktop-full
 
 USER root
 
-#update ROS GPG key: https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669
-RUN curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-
 ENV IS_CI=1
-    
+
 USER root
 
 RUN apt-get update -y -qq \
@@ -27,7 +24,9 @@ RUN apt-get update -y -qq \
       unzip \
       gcc-multilib \
       g++-multilib \ 
-      python-pip 
+      python-pip \
+      vim \
+      openssh-server
 
 RUN pip install --upgrade pip==20.3
 

--- a/mir_perception/mir_object_recognition/ros/include/mir_object_recognition/multimodal_object_recognition_node.h
+++ b/mir_perception/mir_object_recognition/ros/include/mir_object_recognition/multimodal_object_recognition_node.h
@@ -203,8 +203,9 @@ class MultimodalObjectRecognitionROS
     
     /** \brief Transform pointcloud to the given frame id ("base_link" by default)
      * \param[in] PointCloud2 input
+     * \param[out] bool: false if unable to transform pointcloud
     */
-    void preprocessPointCloud(const sensor_msgs::PointCloud2ConstPtr &cloud_msg);
+    bool preprocessPointCloud(const sensor_msgs::PointCloud2ConstPtr &cloud_msg);
 
     /** \brief Add cloud accumulation, segment accumulated pointcloud, find the plane, 
      *     clusters table top objects, find object heights.

--- a/mir_perception/mir_object_recognition/ros/launch/multimodal_object_recognition.launch
+++ b/mir_perception/mir_object_recognition/ros/launch/multimodal_object_recognition.launch
@@ -4,7 +4,7 @@
   <arg name="input_pointcloud_topic" default="/arm_cam3d/depth_registered/points" />
   <arg name="input_image_topic" default="/arm_cam3d/rgb/image_raw" />
   <arg name="target_frame" default="base_link" />
-  <!-- for intel realsense d435, use fixed_camera_link as pointcloud_source_frame_id (bug from robocup 2021) -->
+  <!-- for intel realsense d435 on the robot, use fixed_camera_link as pointcloud_source_frame_id (bug from robocup 2021) -->
   <arg name="pointcloud_source_frame_id" default="arm_cam3d_rgb_optical_frame" />
   <arg name="debug_mode" default="true" />
   <arg name="scene_segmentation_config_file" default="$(find mir_object_recognition)/ros/config/scene_segmentation_constraints.yaml" />

--- a/mir_perception/mir_perception_utils/ros/src/pointcloud_utils_ros.cpp
+++ b/mir_perception/mir_perception_utils/ros/src/pointcloud_utils_ros.cpp
@@ -23,7 +23,11 @@ bool pointcloud::transformPointCloudMsg(const boost::shared_ptr<tf::TransformLis
       cloud_in.header.stamp = common_time;
       tf_listener->waitForTransform(target_frame, cloud_in.header.frame_id, ros::Time::now(),
                                     ros::Duration(1.0));
-      pcl_ros::transformPointCloud(target_frame, cloud_in, cloud_out, *tf_listener);
+      bool result = pcl_ros::transformPointCloud(target_frame, cloud_in, cloud_out, *tf_listener);
+      if (!result)
+      {
+        return (false);
+      }
       cloud_out.header.frame_id = target_frame;
     } catch (tf::TransformException &ex) {
       ROS_ERROR("PCL transform error: %s", ex.what());

--- a/mir_planning/mir_planning_bringup/ros/launch/robot.launch
+++ b/mir_planning/mir_planning_bringup/ros/launch/robot.launch
@@ -132,6 +132,7 @@
     <!-- Multimodal object recognition-->
     <include file="$(find mir_object_recognition)/ros/launch/multimodal_object_recognition.launch">
         <arg name="target_frame" value="base_link_static"/>
+        <arg name="pointcloud_source_frame_id" value="fixed_camera_link"/>
     </include>
     <!-- trims 3 last characters of objects in case they come with count information -->
     <!--include file="$(find mcr_poses_along_object)/ros/launch/poses_along_object.launch"/-->


### PR DESCRIPTION
currently the code crashes if it somehow fails to transform the pointcloud. With this PR, it will publish `e_failed` to event_out and prints a more informative error message.