### PR TITLE
update: add package dependacies for mercury_planner pkg

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,7 @@ function install_ros_dependencies {
     sudo rm -rf /etc/ros/rosdep/sources.list.d/*
     sudo rosdep init -q
     rosdep update -q
-    sudo apt install -y -qq python3-rosinstall python3-rosinstall-generator python3-wstool build-essential python3-catkin-tools python3-pip
+    sudo apt install -y -qq python3-rosinstall python3-rosinstall-generator python3-wstool build-essential python3-catkin-tools python3-pip bison flex gawk g++-multilib pypy
     sudo pip3 install catkin_pkg empy
     #sudo rm -rf /var/lib/apt/lists/*
 }


### PR DESCRIPTION
Error message while building mercury_planner package:
```
fatal error: bits/c++config.h: No such file or directory
   38 | #include <bits/c++config.h>
```

<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* install following dependent packages for mercury_planner package: bison flex gawk g++-multilib pypy

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
