### PR TITLE
Fixed import errors in pose_mock_up_gui.py

### DIFF
--- a/mir_manipulation/mir_pregrasp_planning/ros/src/mir_pregrasp_planning_ros/pose_mock_up_gui.py
+++ b/mir_manipulation/mir_pregrasp_planning/ros/src/mir_pregrasp_planning_ros/pose_mock_up_gui.py
@@ -7,7 +7,7 @@ This module contains a component that publishes an artificial object pose.
 
 import math
 import threading
-import Tkinter
+import tkinter as Tkinter
 
 import geometry_msgs.msg
 import rospy
@@ -249,7 +249,7 @@ def publish_pose():
 def main():
     rospy.init_node("target_pose_mock_up")
 
-    import thread
+    import _thread as thread
 
     try:
         thread.start_new_thread(create_window, tuple())


### PR DESCRIPTION
Instead of "import Tkinter", "import tkinter as Tkinter" is used and instead of "import thread", "import _thread as thread" is used. so that rest of the code works fine

<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* Fixed import errors in pose_mock_up_gui.py

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
