### PR TITLE
Fixed python migration error

### DIFF
--- a/mir_planning/mir_knowledge/ros/src/mir_knowledge_ros/problem_uploader.py
+++ b/mir_planning/mir_knowledge/ros/src/mir_knowledge_ros/problem_uploader.py
@@ -88,7 +88,7 @@ class ProblemUploader(object):
 
         """
         ki_list = []
-        for instance_type, instance_names in instances.iteritems():
+        for instance_type, instance_names in instances.items():
             for instance_name in instance_names:
                 ki_list.append(
                     KnowledgeItem(


### PR DESCRIPTION
Changed line 91 from " for instance_type, instance_names in instances.iteritems() " to " for instance_type, instance_names in instances.items()" as iteritems() is discontinued in python 3.x

<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* Changed line 91 from " for instance_type, instance_names in instances.iteritems() " to " for instance_type, instance_names in instances.items()" as iteritems() is discontinued in python 3.x
* 

## Related PRs
<!-- Mention any other pull requests that need to be merged (and in which order, if applicable). -->
<!--If your PR is related to an issue, you can close the issue by using keywords: https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- For example, just write: Closes #31 -->

Closes #XX  
Related to #YY

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [X] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
