### PR TITLE
[urdf] remove redundant joint and link in dynamixel gripper urdf

### DIFF
--- a/mir_common/mir_description/urdf/grippers/dynamixel/v2/dynamixel_gripper.urdf.xacro
+++ b/mir_common/mir_description/urdf/grippers/dynamixel/v2/dynamixel_gripper.urdf.xacro
@@ -29,14 +29,6 @@
     <link name="${name}_static_grasp_link">
     </link>
 
-    <joint name="${name}_static_grasp_link_joint" type="fixed" >
-        <origin xyz="0 0 $(arg grasp_link_offset)" rpy="0 0 0"/>
-      <parent link="${parent}" />
-      <child link="${name}_static_grasp_link" />
-    </joint>
-    <link name="${name}_static_grasp_link">
-    </link>
-
     <!-- motor mount -->
     <link name="${name}_motor_mount_link">
       <inertial>


### PR DESCRIPTION
<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->

## Changelog
* the dynamixel urdf had an extra joint and link which has been removed.

## Related PRs
<!-- Mention any other pull requests that need to be merged (and in which order, if applicable). -->
<!--If your PR is related to an issue, you can close the issue by using keywords: https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- For example, just write: Closes #31 -->

Closes #XX  
Related to #YY

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [ ] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [ ] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
