### PR TITLE
fix typo in documentation and fix cv_bridge header include

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -96,7 +96,8 @@ Setup catkin workspace
   .. code-block:: bash
 
     cd ~/rolling/src/
-    vcs import < mas_industrial_robots/mir.repos
+    vcs import < mas_industrial_robotics/mir.repos
+    rosdep install --from-paths src --ignore-src -r -y
 
   The last command should be added to the ~/.bashrc file so that they do not need to be executed everytime you open a new terminal.
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -88,8 +88,8 @@ Setup catkin workspace
 
   .. code-block:: bash
 
-    cd ~/noetic/src;
-    git clone -b humble https://github.com/mas_industrial_robotics.git
+    cd ~/rolling/src;
+    git clone -b rolling https://github.com/mas_industrial_robotics.git
 
   Then go on with installing further external dependencies:
 

--- a/mir_command_tools/mir_teleop/package.xml
+++ b/mir_command_tools/mir_teleop/package.xml
@@ -20,6 +20,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
   <depend>mir_interfaces</depend>
+  <depend>moveit_msgs</depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/mir_perception/mir_object_recognition/ros/include/mir_object_recognition/multimodal_object_recognition_utils.hpp
+++ b/mir_perception/mir_object_recognition/ros/include/mir_object_recognition/multimodal_object_recognition_utils.hpp
@@ -9,7 +9,7 @@
 #ifndef MIR_OBJECT_RECOGNITION_MULTIMODAL_OBJECT_RECOGNITION_UTILS_HPP
 #define MIR_OBJECT_RECOGNITION_MULTIMODAL_OBJECT_RECOGNITION_UTILS_HPP
 
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.h>
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <tf2_ros/transform_listener.h>

--- a/mir_perception/mir_perception_utils/ros/include/mir_perception_utils/object_utils_ros.hpp
+++ b/mir_perception/mir_perception_utils/ros/include/mir_perception_utils/object_utils_ros.hpp
@@ -16,7 +16,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-#include "cv_bridge/cv_bridge.hpp"
+#include "cv_bridge/cv_bridge.h"
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>

--- a/mir_perception/mir_perception_utils/ros/src/object_utils_ros.cpp
+++ b/mir_perception/mir_perception_utils/ros/src/object_utils_ros.cpp
@@ -34,7 +34,7 @@
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.h>
 // pcl_ros is not converted to ros2 yet, hence commented out
 // #include <pcl_ros/point_cloud.hpp>
 

--- a/mir_robots/mir_bringup/package.xml
+++ b/mir_robots/mir_bringup/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>youbot_driver</exec_depend>
   <exec_depend>mir_twist_mux</exec_depend>
   <depend>mir_gripper_controller</depend>
+  <depend>urg_node</depend>
 
   <depend>youbot_driver_ros_interface</depend>
 


### PR DESCRIPTION
<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

- Fixed typos in the docs
- Added rosdep command in docs for auto install dependencies
- Change header includeo for `cv_bridge`, for some reason it's required to use `.h` instead of `.hpp`

## Related PRs
<!-- Mention any other pull requests that need to be merged (and in which order, if applicable). -->
<!--If your PR is related to an issue, you can close the issue by using keywords: https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- For example, just write: Closes #31 -->

Closes #XX  
Related to #YY

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
